### PR TITLE
Add optional extension bytes to in-system snapshots and log reports

### DIFF
--- a/ekotrace-udp-collector/src/lib.rs
+++ b/ekotrace-udp-collector/src/lib.rs
@@ -234,6 +234,7 @@ mod tests {
                     events: vec![793, 2384],
                 },
             ],
+            extension_bytes: vec![],
         }
     }
 

--- a/schemas/in_system.lcm
+++ b/schemas/in_system.lcm
@@ -4,6 +4,8 @@ struct causal_snapshot {
     int32_t tracer_id;
     int32_t n_clocks;
     logical_clock clocks[n_clocks];
+    int32_t n_extension_bytes;
+    byte extension_bytes[n_extension_bytes];
 }
 
 struct logical_clock {

--- a/schemas/log_reporting.lcm
+++ b/schemas/log_reporting.lcm
@@ -5,6 +5,8 @@ struct log_report {
     error_flags flags;
     int32_t n_segments;
     log_segment segments[n_segments];
+    int32_t n_extension_bytes;
+    byte extension_bytes[n_extension_bytes];
 }
 
 struct error_flags {


### PR DESCRIPTION
A critical escape hatch for optional proprietary additions to the open snapshot and report formats.