### PR TITLE
Split off Tracer trait, more inline hinting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -734,7 +734,7 @@ name = "regex"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1050,7 +1050,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+"checksum aho-corasick 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5f56c476256dc249def911d6f7580b5fc7e875895b5d7ee88f5d602208035744"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"

--- a/ekotrace-udp-collector/src/lib.rs
+++ b/ekotrace-udp-collector/src/lib.rs
@@ -205,6 +205,7 @@ fn add_log_report_to_entries(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ekotrace::Tracer;
     use std::collections::HashSet;
     use std::net::{Ipv4Addr, SocketAddrV4, TcpListener};
     use std::sync::atomic::{AtomicU16, AtomicU32, Ordering};

--- a/ekotrace/src/history.rs
+++ b/ekotrace/src/history.rs
@@ -206,6 +206,7 @@ struct ClocksFullError;
 
 impl DynamicHistory {
     #[allow(clippy::cast_ptr_alignment)]
+    #[inline]
     pub fn new_at(
         destination: &mut [u8],
         tracer_id: TracerId,
@@ -315,6 +316,7 @@ impl DynamicHistory {
         }
     }
 
+    #[inline]
     fn try_push_clock(&mut self, clock: LogicalClock) -> Result<(), ClocksFullError> {
         if self.clocks_len < self.config.max_clocks_len as usize {
             unsafe {
@@ -327,16 +329,19 @@ impl DynamicHistory {
         }
     }
 
+    #[inline]
     fn get_clocks_slice(&self) -> &[LogicalClock] {
         unsafe { core::slice::from_raw_parts(self.clocks as *const LogicalClock, self.clocks_len) }
     }
 
+    #[inline]
     fn get_clocks_slice_mut(&mut self) -> &mut [LogicalClock] {
         unsafe {
             core::slice::from_raw_parts_mut(self.clocks as *mut LogicalClock, self.clocks_len)
         }
     }
 
+    #[inline]
     fn get_log_slice(&self) -> &[CompactLogItem] {
         unsafe {
             core::slice::from_raw_parts(
@@ -346,6 +351,7 @@ impl DynamicHistory {
         }
     }
 
+    #[inline]
     fn clear_log(&mut self) {
         self.log_len = 0;
         self.has_overflowed_log = false;
@@ -371,6 +377,7 @@ impl DynamicHistory {
     }
 
     /// Increments the clock in the logical clock corresponding to this tracer instance
+    #[inline]
     fn increment_local_clock_count(&mut self) {
         // N.B. We rely on the fact that the first member of the clocks
         // collection is always the clock for this tracer
@@ -383,6 +390,7 @@ impl DynamicHistory {
     /// within the system under test.
     ///
     /// If the write was successful, returns the number of bytes written.
+    #[inline]
     pub(crate) fn write_lcm_logical_clock(
         &mut self,
         destination: &mut [u8],
@@ -414,6 +422,7 @@ impl DynamicHistory {
 
     /// Produce a transparent but limited snapshot of the causal state for transmission
     /// within the system under test
+    #[inline]
     pub(crate) fn write_fixed_size_logical_clock(
         &mut self,
     ) -> Result<CausalSnapshot, DistributeError> {
@@ -440,16 +449,19 @@ impl DynamicHistory {
             clocks_len: non_empty_clocks_count as u8,
         })
     }
+    #[inline]
     pub(crate) fn merge_from_lcm_log_report_bytes(
         &mut self,
         source: &[u8],
     ) -> Result<(), MergeError> {
         impl From<DecodeValueError<rust_lcm_codec::BufferReaderError>> for MergeError {
+            #[inline]
             fn from(_: DecodeValueError<rust_lcm_codec::BufferReaderError>) -> Self {
                 MergeError::ExternalHistoryEncoding
             }
         }
         impl From<DecodeFingerprintError<rust_lcm_codec::BufferReaderError>> for MergeError {
+            #[inline]
             fn from(_: DecodeFingerprintError<rust_lcm_codec::BufferReaderError>) -> Self {
                 MergeError::ExternalHistoryEncoding
             }
@@ -491,6 +503,7 @@ impl DynamicHistory {
     }
 
     /// Merge a publicly-transmittable causal history into our specialized local in-memory storage
+    #[inline]
     pub(crate) fn merge_fixed_size(
         &mut self,
         external_history: &CausalSnapshot,
@@ -506,6 +519,7 @@ impl DynamicHistory {
         )
     }
 
+    #[inline]
     fn merge_internal<B>(
         &mut self,
         raw_neighbor_id: u32,
@@ -572,6 +586,7 @@ impl DynamicHistory {
         outcome
     }
 
+    #[inline]
     fn write_current_clocks_to_log(&mut self) {
         if self.has_overflowed_log {
             return;
@@ -603,6 +618,7 @@ impl DynamicHistory {
     ///   * Error flags
     ///   * Event ids for events that have happened since the last backend send
     ///   * Interspersed snapshots of the logical clock
+    #[inline]
     pub(crate) fn write_lcm_log_report(
         &mut self,
         destination: &mut [u8],
@@ -668,6 +684,7 @@ impl DynamicHistory {
 }
 
 impl From<EncodeValueError<rust_lcm_codec::BufferWriterError>> for DistributeError {
+    #[inline]
     fn from(e: EncodeValueError<rust_lcm_codec::BufferWriterError>) -> Self {
         match e {
             EncodeValueError::ArrayLengthMismatch(_) => DistributeError::Encoding,
@@ -679,12 +696,14 @@ impl From<EncodeValueError<rust_lcm_codec::BufferWriterError>> for DistributeErr
 impl From<rust_lcm_codec::EncodeFingerprintError<rust_lcm_codec::BufferWriterError>>
     for DistributeError
 {
+    #[inline]
     fn from(_: rust_lcm_codec::EncodeFingerprintError<rust_lcm_codec::BufferWriterError>) -> Self {
         DistributeError::InsufficientDestinationSize
     }
 }
 
 impl From<EncodeValueError<rust_lcm_codec::BufferWriterError>> for ReportError {
+    #[inline]
     fn from(e: EncodeValueError<rust_lcm_codec::BufferWriterError>) -> Self {
         match e {
             EncodeValueError::ArrayLengthMismatch(_) => ReportError::Encoding,
@@ -696,6 +715,7 @@ impl From<EncodeValueError<rust_lcm_codec::BufferWriterError>> for ReportError {
 impl From<rust_lcm_codec::EncodeFingerprintError<rust_lcm_codec::BufferWriterError>>
     for ReportError
 {
+    #[inline]
     fn from(_: rust_lcm_codec::EncodeFingerprintError<rust_lcm_codec::BufferWriterError>) -> Self {
         ReportError::InsufficientDestinationSize
     }


### PR DESCRIPTION
Make it easier to provide alternate implementations of the core ekotrace operations.