### PR TITLE
Use the public release of the rust-lcm crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.3.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "c2-chacha"
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
+checksum = "ca2be23073829399f39689074cca6997d929a634f73e5d08e24323c30c01832e"
 dependencies = [
  "memchr",
 ]
@@ -441,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b54058f0a6ff80b6803da8faf8997cde53872b38f4023728f6830b06cd3c0dc"
+checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 dependencies = [
  "autocfg 1.0.0",
 ]
@@ -499,12 +499,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.0"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
-dependencies = [
- "libc",
-]
+checksum = "53445de381a1f436797497c61d851644d0e8e88e6140f22872ad33a704933978"
 
 [[package]]
 name = "memoffset"
@@ -583,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875077759af22fa20b610ad4471d8155b321c89c3f2785526c9839b099be4e0a"
+checksum = "052b3c9af39c7e5e94245f820530487d19eb285faedcb40e0c3275132293f242"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
@@ -596,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5717d9fa2664351a01ed73ba5ef6df09c01a521cb42cb65a061432a826f3c7a"
+checksum = "d175bef481c7902e63e3165627123fff3502f06ac043d3ef42d08c1246da9253"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -852,12 +849,14 @@ dependencies = [
 [[package]]
 name = "rust-lcm-codec"
 version = "0.2.0"
-source = "git+ssh://git@github.com/auxoncorp/rust-lcm-codec.git#11b00c6fe41a0fcca6f9d7295ae58ab9e82e39ec"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e28812742af61232011d39fc8359fad77fc50edbdee7128552b4b56a414e2e"
 
 [[package]]
 name = "rust-lcm-codegen"
 version = "0.2.0"
-source = "git+ssh://git@github.com/auxoncorp/rust-lcm-codec.git#11b00c6fe41a0fcca6f9d7295ae58ab9e82e39ec"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d071bd1706d50f03fb9a538ca8965afbd3988bd55cb1571ba7c8611d6f722f6"
 dependencies = [
  "nom",
  "proc-macro2",

--- a/alloc-log-report/Cargo.toml
+++ b/alloc-log-report/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/auxoncorp/ekotrace"
 name = "alloc_log_report"
 
 [dependencies]
-rust-lcm-codec = { git = "ssh://git@github.com/auxoncorp/rust-lcm-codec.git", branch = "master"}
+rust-lcm-codec = "0.2"
 
 [build-dependencies]
-rust-lcm-codegen = { git = "ssh://git@github.com/auxoncorp/rust-lcm-codec.git", branch = "master"}
+rust-lcm-codegen = "0.2"

--- a/ekotrace/Cargo.toml
+++ b/ekotrace/Cargo.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 
 [dependencies]
 static_assertions = "1.1.0"
-rust-lcm-codec = { git = "ssh://git@github.com/auxoncorp/rust-lcm-codec.git", branch = "master"}
+rust-lcm-codec = "0.2"
 fixed-slice-vec = "0.2"
 
 [dev-dependencies]
 alloc-log-report = { path = "../alloc-log-report" }
 
 [build-dependencies]
-rust-lcm-codegen = { git = "ssh://git@github.com/auxoncorp/rust-lcm-codec.git", branch = "master"}
+rust-lcm-codegen = "0.2"


### PR DESCRIPTION
This should make versioning more consistent.