### PR TITLE
Put the original authors back in

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "ekotrace"
 version = "0.2.0"
-authors = ["Zachary Pierce <zack@auxon.io>"]
+authors = [
+    "Zachary Pierce <zack@auxon.io>",
+    "Russell Mull <russell@auxon.io>",
+    "dan pittman <dan@auxon.io>",
+    "Jon Lamb <jon@auxon.io>"
+]
 edition = "2018"
 license = "Apache-2.0"
 repository = "https://github.com/auxoncorp/ekotrace"

--- a/ekotrace-cli/Cargo.toml
+++ b/ekotrace-cli/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "ekotrace-cli"
 version = "0.1.0"
-authors = ["Jon Lamb <jon@auxon.io>"]
+authors = [
+    "Zachary Pierce <zack@auxon.io>",
+    "Russell Mull <russell@auxon.io>",
+    "Jon Lamb <jon@auxon.io>"
+]
 edition = "2018"
 license = "Apache-2.0"
 repository = "https://github.com/auxoncorp/ekotrace"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "util"
 version = "0.1.0"
-authors = ["Jon Lamb <jon@auxon.io>"]
+authors = ["Zachary Pierce <zack@auxon.io>", "Russell Mull <russell@auxon.io>"]
 edition = "2018"
 license = "Apache-2.0"
 repository = "https://github.com/auxoncorp/ekotrace"


### PR DESCRIPTION
We lost the original authors when I `cargo new`'d the new projects.
This commit puts them back in.