### PR TITLE
Rename with_metadata to with_payload

### DIFF
--- a/ekotrace-capi/ctest/test.c
+++ b/ekotrace-capi/ctest/test.c
@@ -14,7 +14,7 @@ static uint32_t EVENT_A = 100;
 bool test_backend_piping() {
     bool passed = true;
     uint8_t * destination = (uint8_t*)malloc(DEFAULT_TRACER_SIZE);
-    ekotrace * t;
+    ekotrace * t = EKOTRACE_NULL_TRACER_INITIALIZER;
     ekotrace_result result = ekotrace_initialize(destination, DEFAULT_TRACER_SIZE, DEFAULT_TRACER_ID, &t);
     if (result != EKOTRACE_RESULT_OK) {
         passed = false;
@@ -72,49 +72,49 @@ bool test_event_recording() {
         fprintf(stderr, "failed at record event: %d\n", result);
         passed = false;
     }
-    result = ekotrace_record_event_with_metadata(t, EVENT_A, 1);
+    result = ekotrace_record_event_with_payload(t, EVENT_A, 1);
     if (result != EKOTRACE_RESULT_OK) {
-        fprintf(stderr, "failed at record event with metadata: %d\n", result);
+        fprintf(stderr, "failed at record event with payload: %d\n", result);
         passed = false;
     }
     result = EKOTRACE_RECORD_W_I8(t, EVENT_A, (int8_t) 1);
     if (result != EKOTRACE_RESULT_OK) {
-        fprintf(stderr, "failed at record event with metadata: %d\n", result);
+        fprintf(stderr, "failed at record event with payload: %d\n", result);
         passed = false;
     }
     result = EKOTRACE_RECORD_W_U8(t, EVENT_A, (uint8_t) 1, "more docs");
     if (result != EKOTRACE_RESULT_OK) {
-        fprintf(stderr, "failed at record event with metadata: %d\n", result);
+        fprintf(stderr, "failed at record event with payload: %d\n", result);
         passed = false;
     }
     result = EKOTRACE_RECORD_W_I16(t, EVENT_A, (int16_t) 1);
     if (result != EKOTRACE_RESULT_OK) {
-        fprintf(stderr, "failed at record event with metadata: %d\n", result);
+        fprintf(stderr, "failed at record event with payload: %d\n", result);
         passed = false;
     }
     result = EKOTRACE_RECORD_W_U16(t, EVENT_A, (uint16_t) 1);
     if (result != EKOTRACE_RESULT_OK) {
-        fprintf(stderr, "failed at record event with metadata: %d\n", result);
+        fprintf(stderr, "failed at record event with payload: %d\n", result);
         passed = false;
     }
     result = EKOTRACE_RECORD_W_I32(t, EVENT_A, (int32_t) 1, "some docs");
     if (result != EKOTRACE_RESULT_OK) {
-        fprintf(stderr, "failed at record event with metadata: %d\n", result);
+        fprintf(stderr, "failed at record event with payload: %d\n", result);
         passed = false;
     }
     result = EKOTRACE_RECORD_W_U32(t, EVENT_A, (uint32_t) 1);
     if (result != EKOTRACE_RESULT_OK) {
-        fprintf(stderr, "failed at record event with metadata: %d\n", result);
+        fprintf(stderr, "failed at record event with payload: %d\n", result);
         passed = false;
     }
     result = EKOTRACE_RECORD_W_BOOL(t, EVENT_A, true, "my docs");
     if (result != EKOTRACE_RESULT_OK) {
-        fprintf(stderr, "failed at record event with metadata: %d\n", result);
+        fprintf(stderr, "failed at record event with payload: %d\n", result);
         passed = false;
     }
     result = EKOTRACE_RECORD_W_F32(t, EVENT_A, 1.23f, "my docs");
     if (result != EKOTRACE_RESULT_OK) {
-        fprintf(stderr, "failed at record event with metadata: %d\n", result);
+        fprintf(stderr, "failed at record event with payload: %d\n", result);
         passed = false;
     }
     causal_snapshot snap_b;

--- a/ekotrace-capi/ekotrace-capi-impl/src/lib.rs
+++ b/ekotrace-capi/ekotrace-capi-impl/src/lib.rs
@@ -107,16 +107,16 @@ pub unsafe fn ekotrace_record_event(
 /// to an initialized instance operating in a single-threaded
 /// fashion.
 #[cfg_attr(feature = "no_mangle", no_mangle)]
-pub unsafe fn ekotrace_record_event_with_metadata(
+pub unsafe fn ekotrace_record_event_with_payload(
     tracer: *mut Ekotrace<'static>,
     event_id: u32,
-    meta: u32,
+    payload: u32,
 ) -> EkotraceResult {
     let tracer = match tracer.as_mut() {
         Some(t) => t,
         None => return EKOTRACE_RESULT_NULL_POINTER,
     };
-    match tracer.try_record_event_with_metadata(event_id, meta) {
+    match tracer.try_record_event_with_payload(event_id, payload) {
         Ok(_) => EKOTRACE_RESULT_OK,
         Err(ekotrace::InvalidEventId) => EKOTRACE_RESULT_INVALID_EVENT_ID,
     }

--- a/ekotrace-capi/include/ekotrace.h
+++ b/ekotrace-capi/include/ekotrace.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-#define EKOTRACE_NULL_TRACER_INITIALIZER NULL
+#define EKOTRACE_NULL_TRACER_INITIALIZER (NULL)
 
 /*
  * Ekotrace is the type of a tracing instance. Expected to be single-threaded.
@@ -127,53 +127,53 @@ typedef struct causal_snapshot {
         ekotrace_record_event(ekt, event)
 
 /*
- * Ekotrace event recording with metadata macro.
+ * Ekotrace event recording with payload macro.
  *
  * Used to expose event recording information to the CLI tooling.
  *
- * Expands to call `ekotrace_record_event_with_metadata_<type>(ekt, event)`.
+ * Expands to call `ekotrace_record_event_with_payload_<type>(ekt, event)`.
  *
  */
-#define EKOTRACE_RECORD_W_I8(ekt, event, meta_data, ...) \
-    ekotrace_record_event_with_metadata_i8(\
+#define EKOTRACE_RECORD_W_I8(ekt, event, payload, ...) \
+    ekotrace_record_event_with_payload_i8(\
             ekt, \
             event, \
-            meta_data)
-#define EKOTRACE_RECORD_W_U8(ekt, event, meta_data, ...) \
-    ekotrace_record_event_with_metadata_u8(\
+            payload)
+#define EKOTRACE_RECORD_W_U8(ekt, event, payload, ...) \
+    ekotrace_record_event_with_payload_u8(\
             ekt, \
             event, \
-            meta_data)
-#define EKOTRACE_RECORD_W_I16(ekt, event, meta_data, ...) \
-    ekotrace_record_event_with_metadata_i16(\
+            payload)
+#define EKOTRACE_RECORD_W_I16(ekt, event, payload, ...) \
+    ekotrace_record_event_with_payload_i16(\
             ekt, \
             event, \
-            meta_data)
-#define EKOTRACE_RECORD_W_U16(ekt, event, meta_data, ...) \
-    ekotrace_record_event_with_metadata_u16(\
+            payload)
+#define EKOTRACE_RECORD_W_U16(ekt, event, payload, ...) \
+    ekotrace_record_event_with_payload_u16(\
             ekt, \
             event, \
-            meta_data)
-#define EKOTRACE_RECORD_W_I32(ekt, event, meta_data, ...) \
-    ekotrace_record_event_with_metadata_i32(\
+            payload)
+#define EKOTRACE_RECORD_W_I32(ekt, event, payload, ...) \
+    ekotrace_record_event_with_payload_i32(\
             ekt, \
             event, \
-            meta_data)
-#define EKOTRACE_RECORD_W_U32(ekt, event, meta_data, ...) \
-    ekotrace_record_event_with_metadata_u32(\
+            payload)
+#define EKOTRACE_RECORD_W_U32(ekt, event, payload, ...) \
+    ekotrace_record_event_with_payload_u32(\
             ekt, \
             event, \
-            meta_data)
-#define EKOTRACE_RECORD_W_BOOL(ekt, event, meta_data, ...) \
-    ekotrace_record_event_with_metadata_bool(\
+            payload)
+#define EKOTRACE_RECORD_W_BOOL(ekt, event, payload, ...) \
+    ekotrace_record_event_with_payload_bool(\
             ekt, \
             event, \
-            meta_data)
-#define EKOTRACE_RECORD_W_F32(ekt, event, meta_data, ...) \
-    ekotrace_record_event_with_metadata_f32(\
+            payload)
+#define EKOTRACE_RECORD_W_F32(ekt, event, payload, ...) \
+    ekotrace_record_event_with_payload_f32(\
             ekt, \
             event, \
-            meta_data)
+            payload)
 
 /*
  * Create a ekotrace instance. ekotrace_id must be non-zero
@@ -191,63 +191,63 @@ size_t ekotrace_record_event(ekotrace *ekotrace, uint32_t event_id);
  *
  * event_id must be non-zero.
  */
-size_t ekotrace_record_event_with_metadata(ekotrace *ekotrace, uint32_t event_id, uint32_t meta);
+size_t ekotrace_record_event_with_payload(ekotrace *ekotrace, uint32_t event_id, uint32_t payload);
 
 /*
  * Record an event along with a i8 payload.
  *
  * event_id must be non-zero.
  */
-size_t ekotrace_record_event_with_metadata_i8(ekotrace *ekotrace, uint32_t event_id, int8_t meta);
+size_t ekotrace_record_event_with_payload_i8(ekotrace *ekotrace, uint32_t event_id, int8_t payload);
 
 /*
  * Record an event along with a u8 payload.
  *
  * event_id must be non-zero.
  */
-size_t ekotrace_record_event_with_metadata_u8(ekotrace *ekotrace, uint32_t event_id, uint8_t meta);
+size_t ekotrace_record_event_with_payload_u8(ekotrace *ekotrace, uint32_t event_id, uint8_t payload);
 
 /*
  * Record an event along with a i16 payload.
  *
  * event_id must be non-zero.
  */
-size_t ekotrace_record_event_with_metadata_i16(ekotrace *ekotrace, uint32_t event_id, int16_t meta);
+size_t ekotrace_record_event_with_payload_i16(ekotrace *ekotrace, uint32_t event_id, int16_t payload);
 
 /*
  * Record an event along with a u16 payload.
  *
  * event_id must be non-zero.
  */
-size_t ekotrace_record_event_with_metadata_u16(ekotrace *ekotrace, uint32_t event_id, uint16_t meta);
+size_t ekotrace_record_event_with_payload_u16(ekotrace *ekotrace, uint32_t event_id, uint16_t payload);
 
 /*
  * Record an event along with a i32 payload.
  *
  * event_id must be non-zero.
  */
-size_t ekotrace_record_event_with_metadata_i32(ekotrace *ekotrace, uint32_t event_id, int32_t meta);
+size_t ekotrace_record_event_with_payload_i32(ekotrace *ekotrace, uint32_t event_id, int32_t payload);
 
 /*
  * Record an event along with a u32 payload.
  *
  * event_id must be non-zero.
  */
-size_t ekotrace_record_event_with_metadata_u32(ekotrace *ekotrace, uint32_t event_id, uint32_t meta);
+size_t ekotrace_record_event_with_payload_u32(ekotrace *ekotrace, uint32_t event_id, uint32_t payload);
 
 /*
  * Record an event along with a bool payload.
  *
  * event_id must be non-zero.
  */
-size_t ekotrace_record_event_with_metadata_bool(ekotrace *ekotrace, uint32_t event_id, bool meta);
+size_t ekotrace_record_event_with_payload_bool(ekotrace *ekotrace, uint32_t event_id, bool payload);
 
 /*
  * Record an event along with a f32 payload.
  *
  * event_id must be non-zero.
  */
-size_t ekotrace_record_event_with_metadata_f32(ekotrace *ekotrace, uint32_t event_id, float meta);
+size_t ekotrace_record_event_with_payload_f32(ekotrace *ekotrace, uint32_t event_id, float payload);
 
 /*
  * Conduct necessary background activities, then

--- a/ekotrace-capi/src/lib.rs
+++ b/ekotrace-capi/src/lib.rs
@@ -23,91 +23,97 @@ pub extern "C" fn ekotrace_record_event(
 }
 
 #[no_mangle]
-pub extern "C" fn ekotrace_record_event_with_metadata(
+pub extern "C" fn ekotrace_record_event_with_payload(
     tracer: *mut Ekotrace<'static>,
     event_id: u32,
-    meta: u32,
+    payload: u32,
 ) -> EkotraceResult {
-    unsafe { ekotrace_capi_impl::ekotrace_record_event_with_metadata(tracer, event_id, meta) }
+    unsafe { ekotrace_capi_impl::ekotrace_record_event_with_payload(tracer, event_id, payload) }
 }
 
 #[no_mangle]
-pub extern "C" fn ekotrace_record_event_with_metadata_i8(
+pub extern "C" fn ekotrace_record_event_with_payload_i8(
     tracer: *mut Ekotrace<'static>,
     event_id: u32,
-    meta: i8,
-) -> EkotraceResult {
-    unsafe { ekotrace_capi_impl::ekotrace_record_event_with_metadata(tracer, event_id, meta as _) }
-}
-
-#[no_mangle]
-pub extern "C" fn ekotrace_record_event_with_metadata_u8(
-    tracer: *mut Ekotrace<'static>,
-    event_id: u32,
-    meta: u8,
+    payload: i8,
 ) -> EkotraceResult {
     unsafe {
-        ekotrace_capi_impl::ekotrace_record_event_with_metadata(tracer, event_id, u32::from(meta))
+        ekotrace_capi_impl::ekotrace_record_event_with_payload(tracer, event_id, payload as _)
     }
 }
 
 #[no_mangle]
-pub extern "C" fn ekotrace_record_event_with_metadata_i16(
+pub extern "C" fn ekotrace_record_event_with_payload_u8(
     tracer: *mut Ekotrace<'static>,
     event_id: u32,
-    meta: i16,
-) -> EkotraceResult {
-    unsafe { ekotrace_capi_impl::ekotrace_record_event_with_metadata(tracer, event_id, meta as _) }
-}
-
-#[no_mangle]
-pub extern "C" fn ekotrace_record_event_with_metadata_u16(
-    tracer: *mut Ekotrace<'static>,
-    event_id: u32,
-    meta: u16,
+    payload: u8,
 ) -> EkotraceResult {
     unsafe {
-        ekotrace_capi_impl::ekotrace_record_event_with_metadata(tracer, event_id, u32::from(meta))
+        ekotrace_capi_impl::ekotrace_record_event_with_payload(tracer, event_id, u32::from(payload))
     }
 }
 
 #[no_mangle]
-pub extern "C" fn ekotrace_record_event_with_metadata_i32(
+pub extern "C" fn ekotrace_record_event_with_payload_i16(
     tracer: *mut Ekotrace<'static>,
     event_id: u32,
-    meta: i32,
-) -> EkotraceResult {
-    unsafe { ekotrace_capi_impl::ekotrace_record_event_with_metadata(tracer, event_id, meta as _) }
-}
-
-#[no_mangle]
-pub extern "C" fn ekotrace_record_event_with_metadata_u32(
-    tracer: *mut Ekotrace<'static>,
-    event_id: u32,
-    meta: u32,
-) -> EkotraceResult {
-    unsafe { ekotrace_capi_impl::ekotrace_record_event_with_metadata(tracer, event_id, meta) }
-}
-
-#[no_mangle]
-pub extern "C" fn ekotrace_record_event_with_metadata_bool(
-    tracer: *mut Ekotrace<'static>,
-    event_id: u32,
-    meta: bool,
+    payload: i16,
 ) -> EkotraceResult {
     unsafe {
-        ekotrace_capi_impl::ekotrace_record_event_with_metadata(tracer, event_id, u32::from(meta))
+        ekotrace_capi_impl::ekotrace_record_event_with_payload(tracer, event_id, payload as _)
     }
 }
 
 #[no_mangle]
-pub extern "C" fn ekotrace_record_event_with_metadata_f32(
+pub extern "C" fn ekotrace_record_event_with_payload_u16(
     tracer: *mut Ekotrace<'static>,
     event_id: u32,
-    meta: f32,
+    payload: u16,
 ) -> EkotraceResult {
     unsafe {
-        ekotrace_capi_impl::ekotrace_record_event_with_metadata(tracer, event_id, meta.to_bits())
+        ekotrace_capi_impl::ekotrace_record_event_with_payload(tracer, event_id, u32::from(payload))
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ekotrace_record_event_with_payload_i32(
+    tracer: *mut Ekotrace<'static>,
+    event_id: u32,
+    payload: i32,
+) -> EkotraceResult {
+    unsafe {
+        ekotrace_capi_impl::ekotrace_record_event_with_payload(tracer, event_id, payload as _)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ekotrace_record_event_with_payload_u32(
+    tracer: *mut Ekotrace<'static>,
+    event_id: u32,
+    payload: u32,
+) -> EkotraceResult {
+    unsafe { ekotrace_capi_impl::ekotrace_record_event_with_payload(tracer, event_id, payload) }
+}
+
+#[no_mangle]
+pub extern "C" fn ekotrace_record_event_with_payload_bool(
+    tracer: *mut Ekotrace<'static>,
+    event_id: u32,
+    payload: bool,
+) -> EkotraceResult {
+    unsafe {
+        ekotrace_capi_impl::ekotrace_record_event_with_payload(tracer, event_id, u32::from(payload))
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ekotrace_record_event_with_payload_f32(
+    tracer: *mut Ekotrace<'static>,
+    event_id: u32,
+    payload: f32,
+) -> EkotraceResult {
+    unsafe {
+        ekotrace_capi_impl::ekotrace_record_event_with_payload(tracer, event_id, payload.to_bits())
     }
 }
 

--- a/ekotrace-cli/src/analysis.rs
+++ b/ekotrace-cli/src/analysis.rs
@@ -152,13 +152,13 @@ impl ClusteredNodeFmt for model::LogEntry {
                 self.segment_index,
                 eid.get_raw(),
             ),
-            model::LogEntryData::EventWithMetadata(eid, meta) => format!(
-                "{}.{}.{}\\nEvent: {}\\nMetadata: {}",
+            model::LogEntryData::EventWithPayload(eid, payload) => format!(
+                "{}.{}.{}\\nEvent: {}\\nPayload: {}",
                 self.session_id.0,
                 self.segment_id.0,
                 self.segment_index,
                 eid.get_raw(),
-                meta
+                payload
             ),
         }
     }

--- a/src/history.rs
+++ b/src/history.rs
@@ -294,24 +294,24 @@ impl<'a> DynamicHistory<'a> {
         }
     }
 
-    /// Add the event and its metadata to the internal log, recording
+    /// Add the event and its payload to the internal log, recording
     /// that this event occurred.
     ///
     /// Note: This function silently drop events if the log has
     /// overflowed.
     #[inline]
-    pub(crate) fn record_event_with_metadata(&mut self, event_id: EventId, meta: u32) {
+    pub(crate) fn record_event_with_payload(&mut self, event_id: EventId, payload: u32) {
         let len = self.compact_log.len();
         let cap = self.compact_log.capacity();
         // Room for two?
         if len + 1 >= cap {
             return;
         }
-        let (ev, meta) = CompactLogItem::event_with_metadata(event_id, meta);
+        let (ev, payload) = CompactLogItem::event_with_payload(event_id, payload);
         if self.compact_log.try_push(ev).is_err() {
             return;
         }
-        if self.compact_log.try_push(meta).is_ok() {
+        if self.compact_log.try_push(payload).is_ok() {
             self.event_count = self.event_count.saturating_add(1);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,12 +61,12 @@ pub trait Tracer {
     fn record_event(&mut self, event_id: EventId);
 
     /// Record that an event occurred with a `u32`'s width's worth (4
-    /// bytes) of context via `meta`. The end user is responsible for
+    /// bytes) of context via `payload`. The end user is responsible for
     /// associating meaning with each event_id.
     ///
     /// Accepts an event_id pre-validated to be within the acceptable
     /// range.
-    fn record_event_with_metadata(&mut self, event_id: EventId, meta: u32);
+    fn record_event_with_payload(&mut self, event_id: EventId, payload: u32);
 
     /// Write a summary of this tracer's causal history for use
     /// by another Tracer elsewhere in the system.
@@ -202,7 +202,7 @@ impl<'a> Ekotrace<'a> {
     }
 
     /// Record that an event occurred and associate some context with
-    /// via a 4-byte payload, `meta`. The end user is responsible for
+    /// via a 4-byte payload, `payload`. The end user is responsible for
     /// associating meaning with each event_id.
     ///
     /// Accepts a primitive event_id and returns an error if the
@@ -210,16 +210,16 @@ impl<'a> Ekotrace<'a> {
     ///
     /// If you're working in Rust and want type assurances around id
     /// kinds or want to avoid the performance penalty of id
-    /// validation every call, use `record_event_with_metadata`
+    /// validation every call, use `record_event_with_payload`
     /// instead.
     #[inline]
-    pub fn try_record_event_with_metadata(
+    pub fn try_record_event_with_payload(
         &mut self,
         event_id: u32,
-        meta: u32,
+        payload: u32,
     ) -> Result<(), InvalidEventId> {
         let event_id = EventId::try_from(event_id)?;
-        self.history.record_event_with_metadata(event_id, meta);
+        self.history.record_event_with_payload(event_id, payload);
         Ok(())
     }
 
@@ -339,8 +339,8 @@ impl<'a> Tracer for Ekotrace<'a> {
         self.history.record_event(event_id);
     }
 
-    fn record_event_with_metadata(&mut self, event_id: EventId, meta: u32) {
-        self.history.record_event_with_metadata(event_id, meta)
+    fn record_event_with_payload(&mut self, event_id: EventId, payload: u32) {
+        self.history.record_event_with_payload(event_id, payload)
     }
 
     #[inline]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,314 +29,314 @@ macro_rules! try_record {
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::record_event_with_metadata](struct.Ekotrace.html#method.record_event_with_metadata).
+/// [Ekotrace::record_event_with_payload](struct.Ekotrace.html#method.record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_i8 {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::record_event_with_metadata](struct.Ekotrace.html#method.record_event_with_metadata).
+/// [Ekotrace::record_event_with_payload](struct.Ekotrace.html#method.record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_u8 {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::record_event_with_metadata](struct.Ekotrace.html#method.record_event_with_metadata).
+/// [Ekotrace::record_event_with_payload](struct.Ekotrace.html#method.record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_i16 {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::record_event_with_metadata](struct.Ekotrace.html#method.record_event_with_metadata).
+/// [Ekotrace::record_event_with_payload](struct.Ekotrace.html#method.record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_u16 {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::record_event_with_metadata](struct.Ekotrace.html#method.record_event_with_metadata).
+/// [Ekotrace::record_event_with_payload](struct.Ekotrace.html#method.record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_i32 {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::record_event_with_metadata](struct.Ekotrace.html#method.record_event_with_metadata).
+/// [Ekotrace::record_event_with_payload](struct.Ekotrace.html#method.record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_u32 {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::record_event_with_metadata](struct.Ekotrace.html#method.record_event_with_metadata).
+/// [Ekotrace::record_event_with_payload](struct.Ekotrace.html#method.record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_bool {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::record_event_with_metadata](struct.Ekotrace.html#method.record_event_with_metadata).
+/// [Ekotrace::record_event_with_payload](struct.Ekotrace.html#method.record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_f32 {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::try_record_event_with_metadata](struct.Ekotrace.html#method.try_record_event_with_metadata).
+/// [Ekotrace::try_record_event_with_payload](struct.Ekotrace.html#method.try_record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_i8 {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __try_record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __try_record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __try_record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __try_record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::try_record_event_with_metadata](struct.Ekotrace.html#method.try_record_event_with_metadata).
+/// [Ekotrace::try_record_event_with_payload](struct.Ekotrace.html#method.try_record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_u8 {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __try_record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __try_record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __try_record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __try_record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::try_record_event_with_metadata](struct.Ekotrace.html#method.try_record_event_with_metadata).
+/// [Ekotrace::try_record_event_with_payload](struct.Ekotrace.html#method.try_record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_i16 {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __try_record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __try_record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __try_record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __try_record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::try_record_event_with_metadata](struct.Ekotrace.html#method.try_record_event_with_metadata).
+/// [Ekotrace::try_record_event_with_payload](struct.Ekotrace.html#method.try_record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_u16 {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __try_record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __try_record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __try_record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __try_record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::try_record_event_with_metadata](struct.Ekotrace.html#method.try_record_event_with_metadata).
+/// [Ekotrace::try_record_event_with_payload](struct.Ekotrace.html#method.try_record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_i32 {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __try_record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __try_record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __try_record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __try_record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::try_record_event_with_metadata](struct.Ekotrace.html#method.try_record_event_with_metadata).
+/// [Ekotrace::try_record_event_with_payload](struct.Ekotrace.html#method.try_record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_u32 {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __try_record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __try_record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __try_record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __try_record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::try_record_event_with_metadata](struct.Ekotrace.html#method.try_record_event_with_metadata).
+/// [Ekotrace::try_record_event_with_payload](struct.Ekotrace.html#method.try_record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_bool {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __try_record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __try_record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __try_record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __try_record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 /// Convenience macro that calls
-/// [Ekotrace::try_record_event_with_metadata](struct.Ekotrace.html#method.try_record_event_with_metadata).
+/// [Ekotrace::try_record_event_with_payload](struct.Ekotrace.html#method.try_record_event_with_payload).
 ///
 /// The optional description string argument compiles away, and is
 /// used only by the CLI tooling.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_f32 {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __try_record_with!($tracer, $event, $meta)
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __try_record_with!($tracer, $event, $payload)
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __try_record_with!($tracer, $event, $meta, $desc)
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __try_record_with!($tracer, $event, $payload, $desc)
     }};
 }
 
 #[doc(hidden)]
 #[macro_export(local_inner_macros)]
 macro_rules! __record_with {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __meta_as_u32_impls!();
-        $tracer.record_event_with_metadata($event, $meta.as_u32())
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __payload_as_u32_impls!();
+        $tracer.record_event_with_payload($event, $payload.as_u32())
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __meta_as_u32_impls!();
-        $tracer.record_event_with_metadata($event, $meta.as_u32())
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __payload_as_u32_impls!();
+        $tracer.record_event_with_payload($event, $payload.as_u32())
     }};
 }
 
 #[doc(hidden)]
 #[macro_export(local_inner_macros)]
 macro_rules! __try_record_with {
-    ($tracer:expr, $event:expr, $meta:expr) => {{
-        __meta_as_u32_impls!();
-        $tracer.try_record_event_with_metadata($event, $meta.as_u32())
+    ($tracer:expr, $event:expr, $payload:expr) => {{
+        __payload_as_u32_impls!();
+        $tracer.try_record_event_with_payload($event, $payload.as_u32())
     }};
-    ($tracer:expr, $event:expr, $meta:expr, $desc:tt) => {{
-        __meta_as_u32_impls!();
-        $tracer.try_record_event_with_metadata($event, $meta.as_u32())
+    ($tracer:expr, $event:expr, $payload:expr, $desc:tt) => {{
+        __payload_as_u32_impls!();
+        $tracer.try_record_event_with_payload($event, $payload.as_u32())
     }};
 }
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! __meta_as_u32_impls {
+macro_rules! __payload_as_u32_impls {
     () => {
-        trait MetaAsU32 {
+        trait PayloadAsU32 {
             fn as_u32(&self) -> u32;
         }
-        impl MetaAsU32 for i8 {
+        impl PayloadAsU32 for i8 {
             fn as_u32(&self) -> u32 {
                 *self as u32
             }
         }
-        impl MetaAsU32 for u8 {
+        impl PayloadAsU32 for u8 {
             fn as_u32(&self) -> u32 {
                 *self as u32
             }
         }
-        impl MetaAsU32 for i16 {
+        impl PayloadAsU32 for i16 {
             fn as_u32(&self) -> u32 {
                 *self as u32
             }
         }
-        impl MetaAsU32 for u16 {
+        impl PayloadAsU32 for u16 {
             fn as_u32(&self) -> u32 {
                 *self as u32
             }
         }
-        impl MetaAsU32 for i32 {
+        impl PayloadAsU32 for i32 {
             fn as_u32(&self) -> u32 {
                 *self as u32
             }
         }
-        impl MetaAsU32 for u32 {
+        impl PayloadAsU32 for u32 {
             fn as_u32(&self) -> u32 {
                 *self
             }
         }
-        impl MetaAsU32 for bool {
+        impl PayloadAsU32 for bool {
             fn as_u32(&self) -> u32 {
                 *self as u32
             }
         }
-        impl MetaAsU32 for f32 {
+        impl PayloadAsU32 for f32 {
             fn as_u32(&self) -> u32 {
                 self.to_bits()
             }

--- a/util/src/alloc_log_report.rs
+++ b/util/src/alloc_log_report.rs
@@ -15,7 +15,7 @@ pub struct LogReport {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Event {
     Event(i32),
-    EventWithMetadata(i32, i32),
+    EventWithPayload(i32, i32),
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -31,9 +31,9 @@ impl LogSegment {
             .fold(Vec::new(), |mut raw_events, event| {
                 match event {
                     Event::Event(id) => raw_events.push(*id),
-                    Event::EventWithMetadata(id, meta) => {
+                    Event::EventWithPayload(id, payload) => {
                         raw_events.push(*id);
-                        raw_events.push(*meta);
+                        raw_events.push(*payload);
                     }
                 }
                 raw_events
@@ -74,17 +74,17 @@ impl LogReport {
                         })?;
                     }
                     let mut sr = sr.done()?;
-                    let mut next_meta = (0, false);
+                    let mut next_payload = (0, false);
                     for event_item_reader in &mut sr {
                         let raw_ev = event_item_reader.read()?;
-                        if let (ev, true) = next_meta {
-                            segment.events.push(Event::EventWithMetadata(ev, raw_ev));
-                            next_meta = (0, false);
+                        if let (ev, true) = next_payload {
+                            segment.events.push(Event::EventWithPayload(ev, raw_ev));
+                            next_payload = (0, false);
                         } else {
-                            if (raw_ev & (super::EVENT_WITH_META_MASK as i32))
-                                == (super::EVENT_WITH_META_MASK as i32)
+                            if (raw_ev & (super::EVENT_WITH_PAYLOAD_MASK as i32))
+                                == (super::EVENT_WITH_PAYLOAD_MASK as i32)
                             {
-                                next_meta = (raw_ev, true);
+                                next_payload = (raw_ev, true);
                                 continue;
                             }
                             segment.events.push(Event::Event(raw_ev));

--- a/util/src/model.rs
+++ b/util/src/model.rs
@@ -51,7 +51,7 @@ pub struct EventId(u32);
 // library that both ekotrace and the udp collector can share?
 impl EventId {
     pub fn new(id: u32) -> Self {
-        EventId(id & !super::EVENT_WITH_META_MASK)
+        EventId(id & !super::EVENT_WITH_PAYLOAD_MASK)
     }
 
     pub fn get_raw(self) -> u32 {
@@ -87,7 +87,7 @@ pub struct TracerMapping {
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum LogEntryData {
     Event(EventId),
-    EventWithMetadata(EventId, u32),
+    EventWithPayload(EventId, u32),
     LogicalClock(TracerId, u32),
 }
 
@@ -139,14 +139,14 @@ pub struct LogEntry {
 impl LogEntry {
     pub fn is_event(&self) -> bool {
         match self.data {
-            LogEntryData::Event(_) | LogEntryData::EventWithMetadata(_, _) => true,
+            LogEntryData::Event(_) | LogEntryData::EventWithPayload(_, _) => true,
             LogEntryData::LogicalClock(_, _) => false,
         }
     }
 
     pub fn is_clock(&self) -> bool {
         match self.data {
-            LogEntryData::Event(_) | LogEntryData::EventWithMetadata(_, _) => false,
+            LogEntryData::Event(_) | LogEntryData::EventWithPayload(_, _) => false,
             LogEntryData::LogicalClock(_, _) => true,
         }
     }
@@ -178,7 +178,7 @@ pub mod test {
     }
 
     pub fn arb_event_id() -> impl Strategy<Value = EventId> {
-        proptest::bits::u32::masked(crate::EVENT_WITH_META_MASK).prop_map(EventId::new)
+        proptest::bits::u32::masked(crate::EVENT_WITH_PAYLOAD_MASK).prop_map(EventId::new)
     }
 
     pub fn arb_tracer_id() -> impl Strategy<Value = TracerId> {


### PR DESCRIPTION
This commit renames all of the `with_metadata` methods and internals
to `with_payload`.

Closes #96 