### PR TITLE
Remove the compact-format masking when materializing events with payloads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-lcm-codec = "0.2"
 
 [dev-dependencies]
 ekotrace-udp-collector = { path = "./ekotrace-udp-collector" }
-proptest = "0.9.5"
+proptest = "0.9"
 util = { path = "./util" }
 
 [build-dependencies]

--- a/ekotrace-cli/Cargo.toml
+++ b/ekotrace-cli/Cargo.toml
@@ -45,5 +45,5 @@ version = "0.4"
 features = ["serde"]
 
 [dev-dependencies]
-proptest = "0.9.4"
+proptest = "0.9"
 pretty_assertions = "0.6"

--- a/ekotrace-udp-collector/Cargo.toml
+++ b/ekotrace-udp-collector/Cargo.toml
@@ -37,6 +37,6 @@ rust-lcm-codegen = "0.2"
 crossbeam = "0.7.3"
 lazy_static = "1.4.0"
 proc-graph = "0.1.0"
-proptest = "0.9.4"
+proptest = "0.9"
 tempfile = "3"
 ekotrace = { path = ".." }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -20,4 +20,4 @@ rust-lcm-codec = "0.2"
 rust-lcm-codegen = "0.2"
 
 [dev-dependencies]
-proptest = "0.9.4"
+proptest = "0.9"


### PR DESCRIPTION
This makes it so that once the stuff has been materialized from LCM into the alloc-friendly struct, we don't care about the compactness or masking traits of the original values at all.