### PR TITLE
Unify the C macro names

### DIFF
--- a/modality-probe-capi/ctest/noop.c
+++ b/modality-probe-capi/ctest/noop.c
@@ -16,7 +16,7 @@ static uint8_t g_storage[DEFAULT_PROBE_SIZE];
 
 int main(void) {
     size_t err;
-    err = MODALITY_INITIALIZE(
+    err = MODALITY_PROBE_INIT(
             &g_storage[0],
             DEFAULT_PROBE_SIZE,
             DEFAULT_PROBE_ID,
@@ -25,41 +25,41 @@ int main(void) {
             "Description");
     assert(err == MODALITY_PROBE_ERROR_OK);
 
-    err = MODALITY_RECORD(
+    err = MODALITY_PROBE_RECORD(
             g_probe,
             EVENT_A,
             "tags=network;file-system;other-tags",
             "Description");
     assert(err == MODALITY_PROBE_ERROR_OK);
-    err = MODALITY_RECORD(
+    err = MODALITY_PROBE_RECORD(
             g_probe,
             EVENT_A,
             "tags=network;file-system;other-tags");
     assert(err == MODALITY_PROBE_ERROR_OK);
-    err = MODALITY_RECORD(
+    err = MODALITY_PROBE_RECORD(
             g_probe,
             EVENT_A,
             "Description");
     assert(err == MODALITY_PROBE_ERROR_OK);
-    err = MODALITY_RECORD(g_probe, EVENT_A);
+    err = MODALITY_PROBE_RECORD(g_probe, EVENT_A);
     assert(err == MODALITY_PROBE_ERROR_OK);
 
     const uint8_t my_data = 12;
-    err = MODALITY_RECORD_W_U8(g_probe, EVENT_A, my_data);
+    err = MODALITY_PROBE_RECORD_W_U8(g_probe, EVENT_A, my_data);
     assert(err == MODALITY_PROBE_ERROR_OK);
-    err = MODALITY_RECORD_W_U8(
+    err = MODALITY_PROBE_RECORD_W_U8(
             g_probe,
             EVENT_A,
             my_data,
             "Description");
     assert(err == MODALITY_PROBE_ERROR_OK);
-    err = MODALITY_RECORD_W_U8(
+    err = MODALITY_PROBE_RECORD_W_U8(
             g_probe,
             EVENT_A,
             my_data,
             "tags=thing1;thing2");
     assert(err == MODALITY_PROBE_ERROR_OK);
-    err = MODALITY_RECORD_W_U8(
+    err = MODALITY_PROBE_RECORD_W_U8(
             g_probe,
             EVENT_A,
             my_data,
@@ -67,22 +67,22 @@ int main(void) {
             "Description");
     assert(err == MODALITY_PROBE_ERROR_OK);
 
-    err = MODALITY_RECORD_W_I8(g_probe, EVENT_A, 0);
+    err = MODALITY_PROBE_RECORD_W_I8(g_probe, EVENT_A, 0);
     assert(err == MODALITY_PROBE_ERROR_OK);
-    err = MODALITY_RECORD_W_I16(g_probe, EVENT_A, 0);
+    err = MODALITY_PROBE_RECORD_W_I16(g_probe, EVENT_A, 0);
     assert(err == MODALITY_PROBE_ERROR_OK);
-    err = MODALITY_RECORD_W_U16(g_probe, EVENT_A, 0);
+    err = MODALITY_PROBE_RECORD_W_U16(g_probe, EVENT_A, 0);
     assert(err == MODALITY_PROBE_ERROR_OK);
-    err = MODALITY_RECORD_W_I32(g_probe, EVENT_A, 0);
+    err = MODALITY_PROBE_RECORD_W_I32(g_probe, EVENT_A, 0);
     assert(err == MODALITY_PROBE_ERROR_OK);
-    err = MODALITY_RECORD_W_U32(g_probe, EVENT_A, 0);
+    err = MODALITY_PROBE_RECORD_W_U32(g_probe, EVENT_A, 0);
     assert(err == MODALITY_PROBE_ERROR_OK);
-    err = MODALITY_RECORD_W_BOOL(g_probe, EVENT_A, false);
+    err = MODALITY_PROBE_RECORD_W_BOOL(g_probe, EVENT_A, false);
     assert(err == MODALITY_PROBE_ERROR_OK);
-    err = MODALITY_RECORD_W_F32(g_probe, EVENT_A, 0.0f);
+    err = MODALITY_PROBE_RECORD_W_F32(g_probe, EVENT_A, 0.0f);
     assert(err == MODALITY_PROBE_ERROR_OK);
 
-    err = MODALITY_EXPECT(g_probe, EVENT_A, 1 == 0);
+    err = MODALITY_PROBE_EXPECT(g_probe, EVENT_A, 1 == 0);
     assert(err == MODALITY_PROBE_ERROR_OK);
 
     return 0;

--- a/modality-probe-capi/ctest/test.c
+++ b/modality-probe-capi/ctest/test.c
@@ -54,7 +54,7 @@ bool test_event_recording(void) {
     bool passed = true;
     uint8_t * destination = (uint8_t*)malloc(DEFAULT_PROBE_SIZE);
     modality_probe * t;
-    modality_probe_error result = MODALITY_INITIALIZE(
+    modality_probe_error result = MODALITY_PROBE_INIT(
             destination,
             DEFAULT_PROBE_SIZE,
             DEFAULT_PROBE_ID,
@@ -76,27 +76,27 @@ bool test_event_recording(void) {
     ERROR_CHECK(result, passed);
     result = modality_probe_record_event_with_payload(t, EVENT_A, 1);
     ERROR_CHECK(result, passed);
-    result = MODALITY_RECORD(t, EVENT_A, (int8_t) 1, "tags=my-tag", "description");
+    result = MODALITY_PROBE_RECORD(t, EVENT_A, (int8_t) 1, "tags=my-tag", "description");
     ERROR_CHECK(result, passed);
-    result = MODALITY_RECORD(t, EVENT_A, (int8_t) 1, "tags=my-tag");
+    result = MODALITY_PROBE_RECORD(t, EVENT_A, (int8_t) 1, "tags=my-tag");
     ERROR_CHECK(result, passed);
-    result = MODALITY_RECORD_W_I8(t, EVENT_A, (int8_t) 1);
+    result = MODALITY_PROBE_RECORD_W_I8(t, EVENT_A, (int8_t) 1);
     ERROR_CHECK(result, passed);
-    result = MODALITY_RECORD_W_U8(t, EVENT_A, (uint8_t) 1, "more docs");
+    result = MODALITY_PROBE_RECORD_W_U8(t, EVENT_A, (uint8_t) 1, "more docs");
     ERROR_CHECK(result, passed);
-    result = MODALITY_RECORD_W_I16(t, EVENT_A, (int16_t) 1, "tags=my tag");
+    result = MODALITY_PROBE_RECORD_W_I16(t, EVENT_A, (int16_t) 1, "tags=my tag");
     ERROR_CHECK(result, passed);
-    result = MODALITY_RECORD_W_U16(t, EVENT_A, (uint16_t) 1, "tags=a-tag", "desc");
+    result = MODALITY_PROBE_RECORD_W_U16(t, EVENT_A, (uint16_t) 1, "tags=a-tag", "desc");
     ERROR_CHECK(result, passed);
-    result = MODALITY_RECORD_W_I32(t, EVENT_A, (int32_t) 1, "some docs");
+    result = MODALITY_PROBE_RECORD_W_I32(t, EVENT_A, (int32_t) 1, "some docs");
     ERROR_CHECK(result, passed);
-    result = MODALITY_RECORD_W_U32(t, EVENT_A, (uint32_t) 1);
+    result = MODALITY_PROBE_RECORD_W_U32(t, EVENT_A, (uint32_t) 1);
     ERROR_CHECK(result, passed);
-    result = MODALITY_RECORD_W_BOOL(t, EVENT_A, true, "my docs");
+    result = MODALITY_PROBE_RECORD_W_BOOL(t, EVENT_A, true, "my docs");
     ERROR_CHECK(result, passed);
-    result = MODALITY_RECORD_W_F32(t, EVENT_A, 1.23f, "my docs");
+    result = MODALITY_PROBE_RECORD_W_F32(t, EVENT_A, 1.23f, "my docs");
     ERROR_CHECK(result, passed);
-    result = MODALITY_EXPECT(t, EVENT_A, 1 == 0, "my docs", "tags=severity.10");
+    result = MODALITY_PROBE_EXPECT(t, EVENT_A, 1 == 0, "my docs", "tags=severity.10");
     ERROR_CHECK(result, passed);
     modality_causal_snapshot snap_b;
     result = modality_probe_distribute_fixed_size_snapshot(t, &snap_b);

--- a/modality-probe-capi/include/probe.h
+++ b/modality-probe-capi/include/probe.h
@@ -147,7 +147,7 @@ typedef struct modality_causal_snapshot {
  * - A string for the probe description
  *
  */
-#define MODALITY_INITIALIZE(dest, dest_size, id, probe, ...) \
+#define MODALITY_PROBE_INIT(dest, dest_size, id, probe, ...) \
     ((MODALITY_PROBE_MACROS_ENABLED) ? modality_probe_initialize(dest, dest_size, id, probe) : MODALITY_PROBE_ERROR_OK)
 
 /*
@@ -162,7 +162,7 @@ typedef struct modality_causal_snapshot {
  * - A string for the event description
  *
  */
-#define MODALITY_RECORD(probe, event, ...) \
+#define MODALITY_PROBE_RECORD(probe, event, ...) \
     ((MODALITY_PROBE_MACROS_ENABLED) ? modality_probe_record_event(probe, event) : MODALITY_PROBE_ERROR_OK)
 
 /*
@@ -177,42 +177,42 @@ typedef struct modality_causal_snapshot {
  * - A string for the event description
  *
  */
-#define MODALITY_RECORD_W_I8(probe, event, payload, ...) \
+#define MODALITY_PROBE_RECORD_W_I8(probe, event, payload, ...) \
     ((MODALITY_PROBE_MACROS_ENABLED) ? modality_probe_record_event_with_payload_i8(\
             probe, \
             event, \
             payload) : MODALITY_PROBE_ERROR_OK)
-#define MODALITY_RECORD_W_U8(probe, event, payload, ...) \
+#define MODALITY_PROBE_RECORD_W_U8(probe, event, payload, ...) \
     ((MODALITY_PROBE_MACROS_ENABLED) ? modality_probe_record_event_with_payload_u8(\
             probe, \
             event, \
             payload) : MODALITY_PROBE_ERROR_OK)
-#define MODALITY_RECORD_W_I16(probe, event, payload, ...) \
+#define MODALITY_PROBE_RECORD_W_I16(probe, event, payload, ...) \
     ((MODALITY_PROBE_MACROS_ENABLED) ? modality_probe_record_event_with_payload_i16(\
             probe, \
             event, \
             payload) : MODALITY_PROBE_ERROR_OK)
-#define MODALITY_RECORD_W_U16(probe, event, payload, ...) \
+#define MODALITY_PROBE_RECORD_W_U16(probe, event, payload, ...) \
     ((MODALITY_PROBE_MACROS_ENABLED) ? modality_probe_record_event_with_payload_u16(\
             probe, \
             event, \
             payload) : MODALITY_PROBE_ERROR_OK)
-#define MODALITY_RECORD_W_I32(probe, event, payload, ...) \
+#define MODALITY_PROBE_RECORD_W_I32(probe, event, payload, ...) \
     ((MODALITY_PROBE_MACROS_ENABLED) ? modality_probe_record_event_with_payload_i32(\
             probe, \
             event, \
             payload) : MODALITY_PROBE_ERROR_OK)
-#define MODALITY_RECORD_W_U32(probe, event, payload, ...) \
+#define MODALITY_PROBE_RECORD_W_U32(probe, event, payload, ...) \
     ((MODALITY_PROBE_MACROS_ENABLED) ? modality_probe_record_event_with_payload_u32(\
             probe, \
             event, \
             payload) : MODALITY_PROBE_ERROR_OK)
-#define MODALITY_RECORD_W_BOOL(probe, event, payload, ...) \
+#define MODALITY_PROBE_RECORD_W_BOOL(probe, event, payload, ...) \
     ((MODALITY_PROBE_MACROS_ENABLED) ? modality_probe_record_event_with_payload_bool(\
             probe, \
             event, \
             payload) : MODALITY_PROBE_ERROR_OK)
-#define MODALITY_RECORD_W_F32(probe, event, payload, ...) \
+#define MODALITY_PROBE_RECORD_W_F32(probe, event, payload, ...) \
     ((MODALITY_PROBE_MACROS_ENABLED) ? modality_probe_record_event_with_payload_f32(\
             probe, \
             event, \
@@ -230,7 +230,7 @@ typedef struct modality_causal_snapshot {
  * - A string for the event description
  *
  */
-#define MODALITY_EXPECT(probe, event, expr, ...) \
+#define MODALITY_PROBE_EXPECT(probe, event, expr, ...) \
     ((MODALITY_PROBE_MACROS_ENABLED) ? modality_probe_record_event_with_payload_u32(\
             probe, \
             event, \


### PR DESCRIPTION
This commit unifies the C probe macro names with the prefix `MODALITY_PROBE`.