### PR TITLE
Replace the wire types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ exclude = ["debian-package", "./collectors"]
 [dependencies]
 static_assertions = "1.1.0"
 fixed-slice-vec = "0.2"
+byteorder = { version = "1.3", default-features = false }
 
 # Used if the std feature is enabled.
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ exclude = ["debian-package", "./collectors"]
 [dependencies]
 static_assertions = "1.1.0"
 fixed-slice-vec = "0.2"
-byteorder = { version = "1.3", default-features = false }
 
 # Used if the std feature is enabled.
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/collectors/modality-probe-udp-collector/src/chunked.rs
+++ b/collectors/modality-probe-udp-collector/src/chunked.rs
@@ -191,16 +191,6 @@ impl ChunkHandler {
 }
 
 pub fn matches_chunk_fingerprint(message_bytes: &[u8]) -> bool {
-    if message_bytes.len()
-        >= std::mem::size_of::<modality_probe::report::chunked::WireChunkHeader>()
-    {
-        [
-            message_bytes[0],
-            message_bytes[1],
-            message_bytes[2],
-            message_bytes[3],
-        ] == modality_probe::report::chunked::chunk_framing_fingerprint()
-    } else {
-        false
-    }
+    let report = modality_probe::wire::ChunkedReport::new_unchecked(&message_bytes[..]);
+    report.check_len().is_ok() && report.check_fingerprint().is_ok()
 }

--- a/collectors/modality-probe-udp-collector/src/chunked.rs
+++ b/collectors/modality-probe-udp-collector/src/chunked.rs
@@ -191,6 +191,6 @@ impl ChunkHandler {
 }
 
 pub fn matches_chunk_fingerprint(message_bytes: &[u8]) -> bool {
-    let report = modality_probe::wire::ChunkedReport::new_unchecked(&message_bytes[..]);
+    let report = modality_probe::wire::WireChunkedReport::new_unchecked(&message_bytes[..]);
     report.check_len().is_ok() && report.check_fingerprint().is_ok()
 }

--- a/collectors/modality-probe-udp-collector/src/lib.rs
+++ b/collectors/modality-probe-udp-collector/src/lib.rs
@@ -144,7 +144,7 @@ pub fn start_receiving_from_socket<W: Write>(
 
         if matches_chunk_fingerprint(&buf[..bytes_read]) {
             chunk_handler.add_incoming_chunk(
-                &buf[..modality_probe::report::chunked::MAX_CHUNK_BYTES],
+                &buf[..modality_probe::wire::chunked_report::ChunkedReport::<&[u8]>::MAX_CHUNK_BYTES],
                 receive_time,
             );
             let owned_reports = chunk_handler.materialize_completed_reports();

--- a/collectors/modality-probe-udp-collector/src/lib.rs
+++ b/collectors/modality-probe-udp-collector/src/lib.rs
@@ -144,7 +144,7 @@ pub fn start_receiving_from_socket<W: Write>(
 
         if matches_chunk_fingerprint(&buf[..bytes_read]) {
             chunk_handler.add_incoming_chunk(
-                &buf[..modality_probe::wire::chunked_report::ChunkedReport::<&[u8]>::MAX_CHUNK_BYTES],
+                &buf[..modality_probe::wire::chunked_report::WireChunkedReport::<&[u8]>::MAX_CHUNK_BYTES],
                 receive_time,
             );
             let owned_reports = chunk_handler.materialize_completed_reports();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod history;
 mod id;
 mod macros;
 pub mod report;
+pub mod wire;
 
 pub use error::*;
 use history::DynamicHistory;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,11 +74,8 @@ impl CausalSnapshot {
     }
 
     /// Writes a causal snapshot into a slice of little endian bytes
-    pub fn write_into_le_bytes(
-        &self,
-        bytes: &mut [u8],
-    ) -> Result<(), wire::CausalSnapshotWireError> {
-        let mut wire = wire::CausalSnapshot::new_unchecked(bytes);
+    pub fn write_into_le_bytes(&self, bytes: &mut [u8]) -> Result<(), wire::MissingBytes> {
+        let mut wire = wire::WireCausalSnapshot::new_unchecked(bytes);
         wire.check_len()?;
         wire.set_probe_id(self.clock.id);
         wire.set_count(self.clock.count);
@@ -92,7 +89,7 @@ impl TryFrom<&[u8]> for CausalSnapshot {
     type Error = wire::CausalSnapshotWireError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        let snapshot = wire::CausalSnapshot::new(bytes)?;
+        let snapshot = wire::WireCausalSnapshot::new(bytes)?;
         Ok(CausalSnapshot {
             clock: LogicalClock {
                 id: snapshot.probe_id()?,

--- a/src/report/bulk.rs
+++ b/src/report/bulk.rs
@@ -1,12 +1,10 @@
-//! A wire protocol for representing Modality probe log reports
-//! that are fragmented into multiple chunks due to sizing
-//! constraints
+//! Bulk Modality probe log reports
 
 use crate::compact_log::CompactLogItem;
 use crate::history::DynamicHistory;
+use crate::wire::{BulkReport, BulkReportWireError};
 use crate::{ExtensionBytes, ProbeId, ReportError};
-use core::mem::{align_of, size_of};
-use static_assertions::{assert_eq_align, const_assert_eq};
+use core::mem::size_of;
 
 /// Write reports all at once into a single byte slice.
 pub trait BulkReporter {
@@ -56,20 +54,17 @@ impl<'log> BulkReporter for BulkReportSourceComponents<'log> {
             // since the extension data is opaque.
             return Err(ReportError::Extension);
         }
-        let required_bytes = size_of::<WireBulkHeader>() + n_log_bytes + n_extension_bytes;
+        let required_bytes = BulkReport::<&[u8]>::buffer_len(n_log_bytes, n_extension_bytes);
         if destination.len() < required_bytes {
             return Err(ReportError::InsufficientDestinationSize);
         }
-        // We consider this relatively safe because WireBulkHeader is a largely
-        // uninterpreted pile of bytes fields all with alignments == 1
-        // and we know from the above check that there's enough size
-        assert_eq_align!(u8, WireBulkHeader);
-        let (header_bytes, payload_bytes) = destination.split_at_mut(size_of::<WireBulkHeader>());
-        let header = unsafe { &mut *(header_bytes.as_mut_ptr() as *mut WireBulkHeader) };
-        header.fingerprint = bulk_framing_fingerprint();
-        header.probe_id = self.probe_id.get_raw().to_le_bytes();
-        header.n_log_bytes = (n_log_bytes as u32).to_le_bytes(); // Checked above for range
-        header.n_extension_bytes = (n_extension_bytes as u32).to_le_bytes(); // Checked above for range
+
+        let mut report = BulkReport::new_unchecked(&mut destination[..]);
+        report.set_fingerprint(BulkReport::<&[u8]>::FINGERPRINT);
+        report.set_probe_id(self.probe_id.get_raw());
+        report.set_n_log_bytes(n_log_bytes as u32); // Checked above for range
+        report.set_n_extension_bytes(n_extension_bytes as u32); // Checked above for range
+        let payload_bytes = report.payload_mut();
 
         let (log_bytes, extension_bytes) = payload_bytes.split_at_mut(n_log_bytes);
         if super::write_log_as_little_endian_bytes(log_bytes, self.log).is_err() {
@@ -120,23 +115,6 @@ impl<'data> BulkReporter for DynamicHistory<'data> {
     }
 }
 
-/// Fixed-sized always-initialized header portion of the bulk report format
-#[repr(C, align(1))]
-pub struct WireBulkHeader {
-    /// A magical (constant) value used as a hint about the
-    /// data encoded in this pile of bytes.
-    pub fingerprint: [u8; 4],
-    /// A u32 representing the probe_id of the
-    /// Modality probe instance producing this report.
-    pub probe_id: [u8; 4],
-    /// How many of the payload bytes are populated with log data?
-    pub n_log_bytes: [u8; 4],
-    /// How many of the payload bytes are populated with extension data?
-    pub n_extension_bytes: [u8; 4],
-}
-const_assert_eq!(1, align_of::<WireBulkHeader>());
-const_assert_eq!(16, size_of::<WireBulkHeader>());
-
 /// Attempt to split a bulk report from its on-the-wire representation
 /// into its constituent parts, without unbounded copying or any allocation.
 ///
@@ -154,32 +132,15 @@ pub fn try_bulk_from_wire_bytes<'b>(
     ),
     ParseBulkFromWireError,
 > {
-    if wire_bytes.len() < size_of::<WireBulkHeader>() {
-        return Err(ParseBulkFromWireError::MissingHeader);
-    }
-    assert_eq_align!(u8, WireBulkHeader);
-    debug_assert_eq!(
-        0,
-        wire_bytes.as_ptr() as usize % align_of::<WireBulkHeader>()
-    );
-    let (header_bytes, payload_bytes) = wire_bytes.split_at(size_of::<WireBulkHeader>());
-    let wire_header = unsafe { &*(header_bytes.as_ptr() as *const WireBulkHeader) };
-    if wire_header.fingerprint != bulk_framing_fingerprint() {
-        return Err(ParseBulkFromWireError::InvalidFingerprint);
-    }
-    let raw_probe_id = u32::from_le_bytes(wire_header.probe_id);
+    let report = BulkReport::new_checked(&wire_bytes[..])?;
+    let payload_bytes = report.payload();
+
+    let raw_probe_id = report.probe_id();
     let probe_id = ProbeId::new(raw_probe_id)
         .ok_or_else(|| ParseBulkFromWireError::InvalidProbeId(raw_probe_id))?;
-    let n_log_bytes = u32::from_le_bytes(wire_header.n_log_bytes);
-    let n_extension_bytes = u32::from_le_bytes(wire_header.n_extension_bytes);
 
-    if payload_bytes.len() < n_log_bytes as usize {
-        return Err(ParseBulkFromWireError::IncompletePayload);
-    }
+    let n_log_bytes = report.n_log_bytes();
     let (log_bytes, extension_bytes) = payload_bytes.split_at(n_log_bytes as usize);
-    if extension_bytes.len() < n_extension_bytes as usize {
-        return Err(ParseBulkFromWireError::IncompletePayload);
-    }
     let log_iter = log_bytes.chunks_exact(4).map(|item_bytes| {
         CompactLogItem::from_raw(u32::from_le_bytes([
             item_bytes[0],
@@ -195,16 +156,18 @@ pub fn try_bulk_from_wire_bytes<'b>(
 /// from the wire representation
 #[derive(Debug, PartialEq, Eq)]
 pub enum ParseBulkFromWireError {
-    /// The fingerprint didn't match expectations
-    InvalidFingerprint,
-    /// There weren't enough bytes for a full header
-    MissingHeader,
-    /// There weren't enough payload bytes (based on
-    /// expectations from inspecting the header).
-    IncompletePayload,
+    /// Wire error
+    /// There was an error attempting to interpret the wire representation
+    Wire(BulkReportWireError),
     /// The probe id didn't follow the rules for being
     /// a valid Modality probe-specifying ProbeId
     InvalidProbeId(u32),
+}
+
+impl From<BulkReportWireError> for ParseBulkFromWireError {
+    fn from(e: BulkReportWireError) -> Self {
+        ParseBulkFromWireError::Wire(e)
+    }
 }
 
 const BULK_FRAMING_FINGERPRINT_SOURCE: u32 = 0x45_42_4C_4B; // EBLK

--- a/src/report/bulk.rs
+++ b/src/report/bulk.rs
@@ -2,7 +2,7 @@
 
 use crate::compact_log::CompactLogItem;
 use crate::history::DynamicHistory;
-use crate::wire::{BulkReport, BulkReportWireError};
+use crate::wire::{BulkReportWireError, WireBulkReport};
 use crate::{ExtensionBytes, ProbeId, ReportError};
 use core::mem::size_of;
 
@@ -54,12 +54,12 @@ impl<'log> BulkReporter for BulkReportSourceComponents<'log> {
             // since the extension data is opaque.
             return Err(ReportError::Extension);
         }
-        let required_bytes = BulkReport::<&[u8]>::buffer_len(n_log_bytes, n_extension_bytes);
+        let required_bytes = WireBulkReport::<&[u8]>::buffer_len(n_log_bytes, n_extension_bytes);
         if destination.len() < required_bytes {
             return Err(ReportError::InsufficientDestinationSize);
         }
 
-        let mut report = BulkReport::new_unchecked(&mut destination[..]);
+        let mut report = WireBulkReport::new_unchecked(&mut destination[..]);
         report.set_fingerprint();
         report.set_probe_id(self.probe_id);
         report.set_n_log_bytes(n_log_bytes as u32); // Checked above for range
@@ -132,7 +132,7 @@ pub fn try_bulk_from_wire_bytes<'b>(
     ),
     BulkReportWireError,
 > {
-    let report = BulkReport::new(&wire_bytes[..])?;
+    let report = WireBulkReport::new(&wire_bytes[..])?;
     let payload_bytes = report.payload();
 
     let probe_id = report.probe_id()?;

--- a/src/report/chunked.rs
+++ b/src/report/chunked.rs
@@ -4,93 +4,19 @@
 
 use crate::compact_log::CompactLogItem;
 use crate::history::DynamicHistory;
+use crate::wire::{ChunkedReport, ChunkedReportWireError};
 use crate::ProbeId;
 use crate::ReportError;
 use core::borrow::Borrow;
-use core::mem::{align_of, size_of, MaybeUninit};
-use static_assertions::{assert_eq_align, assert_eq_size, const_assert_eq, const_assert_ne};
+use core::mem::{size_of, MaybeUninit};
+use static_assertions::const_assert_ne;
 
-/// struct that represents a single report chunk
-/// as it would appear on the wire.
-///
-/// Report chunks have a maximum size of 256 bytes
-/// Report chunks ought to be aligned to 4 since their
-/// payload (in the most common log data type case) is
-/// often best interpreted as 4-byte u32s. However,
-/// this alignment is not mandatory.
-///
-/// Numeric fields are encoded in little endian format.
-#[repr(C, align(1))]
-pub struct WireChunk {
-    /// Fixed-sized always-fully-initialized header portion of the WireChunk format
-    pub header: WireChunkHeader,
-    /// The content of the report chunk, only certain to be initialized
-    /// after a write_next_report_chunk up to offset `header.n_chunk_payload_bytes`.
-    pub payload: [MaybeUninit<u8>; MAX_PAYLOAD_BYTES_PER_CHUNK],
-}
-assert_eq_size!([u32; MAX_CHUNK_U32_WORDS], WireChunk);
-
-/// Fixed-sized always-initialized header portion of the WireChunk format
-#[repr(C, align(1))]
-pub struct WireChunkHeader {
-    /// A magical (constant) value used as a hint about the
-    /// data encoded in this pile of bytes.
-    pub fingerprint: [u8; 4],
-    /// A u32 representing the probe_id of the
-    /// Modality probe instance producing this report.
-    pub probe_id: [u8; 4],
-    /// A u16 representing the group of report chunks to which
-    /// this chunk belongs. Determined by the Modality probe instance.
-    /// Expected, but not guaranteed to be increasing
-    /// and wrapping-overflowing during the lifetime of an Modality probe
-    /// instance.
-    ///
-    /// Erring on the side of a large
-    /// number of these to support cases like:
-    ///   * a long-lasting partition from the report collector whilst reports
-    /// are archived for future sending
-    ///   * a very high report production cadence relative to the transmission cadence
-    pub chunk_group_id: [u8; 2],
-    /// In what ordinal position does this chunk's payload live relative to the other chunks.
-    pub chunk_index: [u8; 2],
-    /// Does this chunk's payload contain log data (0001) or extension data (0010)?
-    pub payload_data_type: u8,
-    /// Is this chunk the last chunk in the report (0001) or not (0000)?
-    pub is_last_chunk: u8,
-    /// Reserved for future enhancements and to make the payload 4-byte aligned
-    ///
-    /// Note that in general, the three bytes of data currently encoding
-    /// `payload_data_type`, `is_last_chunk`, and `reserved`, are ripe for future
-    /// compaction for bit-field use.
-    pub reserved: u8,
-    /// How many of the payload bytes are populated?
-    pub n_chunk_payload_bytes: u8,
-}
-
-const CHUNK_FRAMING_FINGERPRINT_SOURCE: u32 = 0x45_43_4E_4B; // ECNK
-/// Little endian representation of the chunk format's chunk message
-/// fingerprint.
-pub fn chunk_framing_fingerprint() -> [u8; 4] {
-    CHUNK_FRAMING_FINGERPRINT_SOURCE.to_le_bytes()
-}
-
-/// The size of a chunk in bytes
-pub const MAX_CHUNK_BYTES: usize = 256;
 /// The size of a chunk in u32s, the 4-byte pieces we align these messages to.
 pub const MAX_CHUNK_U32_WORDS: usize = 256 / size_of::<u32>();
-/// The maximum number of payload bytes possibly populated
-/// within a chunk.
-pub const MAX_PAYLOAD_BYTES_PER_CHUNK: usize = 256 - size_of::<WireChunkHeader>();
 /// The maximum number of compact log items (events or clocks)
 /// that could fit in a chunk.
 pub const MAX_PAYLOAD_COMPACT_LOG_ITEMS_PER_CHUNK: usize =
-    MAX_PAYLOAD_BYTES_PER_CHUNK / size_of::<CompactLogItem>();
-assert_eq_size!([u8; MAX_CHUNK_BYTES], WireChunk);
-assert_eq_size!([u32; MAX_CHUNK_U32_WORDS], WireChunk);
-const_assert_eq!(MAX_CHUNK_BYTES, size_of::<WireChunk>());
-const_assert_eq!(1, align_of::<WireChunk>());
-const_assert_eq!(1, align_of::<WireChunkHeader>());
-const_assert_eq!(16, size_of::<WireChunkHeader>());
+    ChunkedReport::<&[u8]>::MAX_PAYLOAD_BYTES_PER_CHUNK / size_of::<CompactLogItem>();
 
 const DATA_TYPE_LOG: u8 = 0b0001;
 const DATA_TYPE_EXTENSION: u8 = 0b0010;
@@ -111,28 +37,6 @@ impl ChunkPayloadDataType {
             ChunkPayloadDataType::Log => DATA_TYPE_LOG.to_le(),
             ChunkPayloadDataType::Extension => DATA_TYPE_EXTENSION.to_le(),
         }
-    }
-}
-
-impl From<&mut [u32; MAX_CHUNK_U32_WORDS]> for &mut WireChunk {
-    fn from(exact_array_ref: &mut [u32; MAX_CHUNK_U32_WORDS]) -> Self {
-        // We consider this relatively safe because WireChunk is a largely
-        // uninterpreted pile of bytes fields all with alignments == 1,
-        // and we know from static assertions that the sizes line up.
-        assert_eq_size!([u32; MAX_CHUNK_U32_WORDS], WireChunk);
-        assert_eq_align!(u8, WireChunk);
-        unsafe { &mut *(exact_array_ref.as_mut_ptr() as *mut WireChunk) }
-    }
-}
-
-impl From<&[u32; MAX_CHUNK_U32_WORDS]> for &WireChunk {
-    fn from(exact_array_ref: &[u32; MAX_CHUNK_U32_WORDS]) -> Self {
-        // We consider this relatively safe because WireChunk is a largely
-        // uninterpreted pile of bytes fields all with alignments == 1,
-        // and we know from static assertions that the sizes line up.
-        assert_eq_size!([u32; MAX_CHUNK_U32_WORDS], WireChunk);
-        assert_eq_align!(u8, WireChunk);
-        unsafe { &*(exact_array_ref.as_ptr() as *const WireChunk) }
     }
 }
 
@@ -276,7 +180,7 @@ impl<'data> ChunkedReporter for DynamicHistory<'data> {
             return Ok(0);
         }
 
-        let required_bytes = size_of::<WireChunkHeader>() + n_chunk_payload_bytes;
+        let required_bytes = ChunkedReport::<&[u8]>::buffer_len(n_chunk_payload_bytes);
         if destination.len() < required_bytes {
             return Err(ChunkedReportError::ReportError(
                 ReportError::InsufficientDestinationSize,
@@ -286,23 +190,17 @@ impl<'data> ChunkedReporter for DynamicHistory<'data> {
         let log_slice =
             &self.compact_log.as_slice()[log_index..log_index + items_for_current_chunk];
 
-        assert_eq_align!(u8, WireChunkHeader);
-        debug_assert_eq!(
-            0,
-            destination.as_ptr() as usize % align_of::<WireChunkHeader>()
-        );
-        let header = unsafe { &mut *(destination.as_mut_ptr() as *mut WireChunkHeader) };
-        *header = WireChunkHeader {
-            fingerprint: chunk_framing_fingerprint(),
-            probe_id: self.probe_id.get_raw().to_le_bytes(),
-            chunk_group_id: token.group_id.to_le_bytes(),
-            chunk_index: current_chunk_index.to_le_bytes(),
-            payload_data_type: ChunkPayloadDataType::Log.data_type_le_byte(),
-            reserved: 0,
-            is_last_chunk: u8::from(is_last_chunk).to_le_bytes()[0],
-            n_chunk_payload_bytes: n_chunk_payload_bytes as u8,
-        };
-        let payload_destination = &mut destination[size_of::<WireChunkHeader>()..];
+        let mut report = ChunkedReport::new_unchecked(&mut destination[..]);
+        report.set_fingerprint(ChunkedReport::<&[u8]>::FINGERPRINT);
+        report.set_probe_id(self.probe_id.get_raw());
+        report.set_chunk_group_id(token.group_id);
+        report.set_chunk_index(current_chunk_index);
+        report.set_payload_data_type(ChunkPayloadDataType::Log.data_type_le_byte());
+        report.set_is_last_chunk(u8::from(is_last_chunk));
+        report.set_reserved(0);
+        report.set_n_chunk_payload_bytes(n_chunk_payload_bytes as u8);
+
+        let payload_destination = report.payload_mut();
         super::write_log_as_little_endian_bytes(payload_destination, log_slice)
             .map_err(ChunkedReportError::ReportError)?;
 
@@ -380,30 +278,18 @@ impl NativeChunk {
         borrow_wire_bytes: B,
     ) -> Result<NativeChunk, ParseChunkFromWireError> {
         let wire_bytes = borrow_wire_bytes.borrow();
-        if wire_bytes.len() < size_of::<WireChunkHeader>() {
-            return Err(ParseChunkFromWireError::MissingHeader);
-        }
-        assert_eq_align!(u8, WireChunkHeader);
-        debug_assert_eq!(
-            0,
-            wire_bytes.as_ptr() as usize % align_of::<WireChunkHeader>()
-        );
-        let wire_header = unsafe { &*(wire_bytes.as_ptr() as *const WireChunkHeader) };
-        if wire_header.fingerprint != chunk_framing_fingerprint() {
-            return Err(ParseChunkFromWireError::InvalidFingerprint);
-        }
-        let raw_probe_id = u32::from_le_bytes(wire_header.probe_id);
-        let chunk_group_id = u16::from_le_bytes(wire_header.chunk_group_id);
-        let chunk_index = u16::from_le_bytes(wire_header.chunk_index);
+
+        let report = ChunkedReport::new_checked(&wire_bytes[..])?;
+
+        let raw_probe_id = report.probe_id();
+        let chunk_group_id = report.chunk_group_id();
+        let chunk_index = report.chunk_index();
         let probe_id = ProbeId::new(raw_probe_id)
             .ok_or_else(|| ParseChunkFromWireError::InvalidProbeId(raw_probe_id))?;
-        let is_last_chunk = u8::from_le_bytes([wire_header.n_chunk_payload_bytes]) != 0;
-        let reserved = u8::from_le_bytes([wire_header.reserved]);
-        let n_payload_bytes = u8::from_le_bytes([wire_header.n_chunk_payload_bytes]);
-        if usize::from(n_payload_bytes) > MAX_PAYLOAD_BYTES_PER_CHUNK {
-            return Err(ParseChunkFromWireError::TooManyPayloadBytes);
-        }
-        let data_type_byte = u8::from_le_bytes([wire_header.payload_data_type]);
+        let is_last_chunk = report.is_last_chunk() != 0;
+        let reserved = report.reserved();
+        let n_payload_bytes = report.n_chunk_payload_bytes();
+        let data_type_byte = report.payload_data_type();
 
         let header = NativeChunkHeader {
             probe_id,
@@ -412,11 +298,7 @@ impl NativeChunk {
             is_last_chunk,
             reserved,
         };
-        let payload_bytes = &wire_bytes[size_of::<WireChunkHeader>()..];
-        if payload_bytes.len() < usize::from(n_payload_bytes) {
-            return Err(ParseChunkFromWireError::IncompletePayload);
-        }
-        let payload_bytes = &payload_bytes[..usize::from(n_payload_bytes)];
+        let payload_bytes = &report.payload()[..usize::from(n_payload_bytes)];
         Ok(match data_type_byte {
             DATA_TYPE_LOG => {
                 // Assuming init is always safe when initializing an array of MaybeUninit values
@@ -444,7 +326,8 @@ impl NativeChunk {
             }
             DATA_TYPE_EXTENSION => {
                 // Assuming init is always safe when initializing an array of MaybeUninit values
-                let mut payload: [MaybeUninit<u8>; MAX_PAYLOAD_BYTES_PER_CHUNK] =
+                let mut payload: [MaybeUninit<u8>;
+                    ChunkedReport::<&[u8]>::MAX_PAYLOAD_BYTES_PER_CHUNK] =
                     unsafe { MaybeUninit::uninit().assume_init() };
                 for (source, sink) in payload_bytes.iter().zip(payload.iter_mut()) {
                     *sink = MaybeUninit::new(*source);
@@ -467,21 +350,20 @@ impl NativeChunk {
 /// Everything that can go wrong converting bytes off the wire to a NativeChunk
 #[derive(Debug, PartialEq, Eq)]
 pub enum ParseChunkFromWireError {
-    /// The fingerprint didn't match expectations
-    InvalidFingerprint,
-    /// There weren't enough bytes for a full header
-    MissingHeader,
-    /// The header supplied a n_payload_bytes value
-    /// greater than the allowed maximum, `MAX_PAYLOAD_BYTES_PER_CHUNK`
-    TooManyPayloadBytes,
-    /// There weren't enough payload bytes (based on
-    /// expectations from inspecting the header).
-    IncompletePayload,
+    /// Wire error
+    /// There was an error attempting to interpret the wire representation
+    Wire(ChunkedReportWireError),
     /// The data type was not one of the supported varieties
     UnsupportedDataType(u8),
     /// The probe id didn't follow the rules for being
     /// a valid Modality probe-specifying ProbeId
     InvalidProbeId(u32),
+}
+
+impl From<ChunkedReportWireError> for ParseChunkFromWireError {
+    fn from(e: ChunkedReportWireError) -> Self {
+        ParseChunkFromWireError::Wire(e)
+    }
 }
 
 /// Chunk framing information, owned and accessible in the native
@@ -558,7 +440,7 @@ pub struct NativeChunkExtensionContents {
     /// How many of the payload bytes are populated?
     n_chunk_payload_bytes: u8,
     /// The content of the report chunk
-    payload: [MaybeUninit<u8>; MAX_PAYLOAD_BYTES_PER_CHUNK],
+    payload: [MaybeUninit<u8>; ChunkedReport::<&[u8]>::MAX_PAYLOAD_BYTES_PER_CHUNK],
 }
 
 impl PartialEq for NativeChunkExtensionContents {
@@ -600,17 +482,13 @@ mod tests {
     use crate::compact_log::log_tests::*;
     use crate::compact_log::LogEvent;
     use crate::id::*;
+    use crate::wire::chunked_report::*;
     use crate::*;
     use core::convert::TryInto;
     use proptest::prelude::*;
     use proptest::std_facade::*;
-    #[test]
-    fn fingerprint_function_matches_expectation() {
-        assert_eq!(
-            u32::from_le_bytes(chunk_framing_fingerprint()),
-            CHUNK_FRAMING_FINGERPRINT_SOURCE
-        );
-    }
+
+    const MAX_CHUNK_BYTES: usize = ChunkedReport::<&[u8]>::MAX_CHUNK_BYTES;
 
     #[test]
     fn chunked_report_happy_path_single_chunk() {
@@ -627,7 +505,7 @@ mod tests {
             .expect("Could not write chunk");
         // For now, we expect just a single logical clock (the local one) to be written in the log since no events were recorded
         // and no other logical histories merged in.
-        let expected_size_bytes = size_of::<WireChunkHeader>() + size_of::<LogicalClock>();
+        let expected_size_bytes = ChunkedReport::<&[u8]>::buffer_len(size_of::<LogicalClock>());
         assert_eq!(expected_size_bytes, n_report_bytes);
         let n_report_bytes = eko
             .write_next_report_chunk(&token, &mut report_transmission_buffer)
@@ -660,7 +538,8 @@ mod tests {
             .write_next_report_chunk(&token, &mut report_transmission_buffer)
             .expect("Could not write chunk");
         // Two events shouldn't have been able to fit in the prior report
-        let expected_size_bytes = size_of::<WireChunkHeader>() + 2 * size_of::<CompactLogItem>();
+        let expected_size_bytes =
+            ChunkedReport::<&[u8]>::buffer_len(2 * size_of::<CompactLogItem>());
         assert_eq!(expected_size_bytes, n_report_bytes);
         let n_report_bytes = eko
             .write_next_report_chunk(&token, &mut report_transmission_buffer)
@@ -720,7 +599,7 @@ mod tests {
             .expect("Could not write chunk");
         // For now, we expect just a single logical clock (the local one) to be written in the log since no events were recorded
         // and no other logical histories merged in.
-        let expected_size_bytes = size_of::<WireChunkHeader>() + size_of::<LogicalClock>();
+        let expected_size_bytes = ChunkedReport::<&[u8]>::buffer_len(size_of::<LogicalClock>());
         assert_eq!(expected_size_bytes, n_report_bytes);
         let n_report_bytes = eko_foo
             .write_next_report_chunk(&token, &mut report_transmission_buffer)
@@ -776,7 +655,7 @@ mod tests {
                 .unwrap_err()
         );
         // Starts to work when you give it a minimally-sized buffer
-        let expected_size_bytes = size_of::<WireChunkHeader>() + size_of::<LogicalClock>();
+        let expected_size_bytes = ChunkedReport::<&[u8]>::buffer_len(size_of::<LogicalClock>());
         assert_eq!(
             expected_size_bytes,
             eko.write_next_report_chunk(

--- a/src/report/wire.rs
+++ b/src/report/wire.rs
@@ -2,7 +2,8 @@
 //! serialization and deserialization.
 use crate::{
     compact_log::{CompactLogItem, LogEvent, LogItem, LogItemInterpretationError, LogItemIterator},
-    report::bulk::{self, BulkReportSourceComponents, BulkReporter, ParseBulkFromWireError},
+    report::bulk::{self, BulkReportSourceComponents, BulkReporter},
+    wire::BulkReportWireError,
     ExtensionBytes, LogicalClock, ProbeId, ReportError,
 };
 
@@ -130,7 +131,7 @@ impl LogReport {
 #[derive(Debug)]
 pub enum ParseBulkReportError {
     /// Parsing the wire format failed.
-    ParseBulkFromWire(ParseBulkFromWireError),
+    ParseBulkFromWire(BulkReportWireError),
     /// Parsing was successful, but the resulting report was broken.
     CompactLogInterpretation(LogItemInterpretationError),
 }

--- a/src/wire/bulk_report.rs
+++ b/src/wire/bulk_report.rs
@@ -1,7 +1,6 @@
 //! A wire protocol for representing Modality probe log reports in bulk form
 
-use crate::ProbeId;
-use byteorder::{ByteOrder, LittleEndian};
+use crate::{wire::le_bytes, ProbeId};
 
 /// Everything that can go wrong when attempting to interpret a bulk report
 /// from the wire representation
@@ -137,14 +136,14 @@ impl<T: AsRef<[u8]>> BulkReport<T> {
     #[inline]
     pub fn fingerprint(&self) -> u32 {
         let data = self.buffer.as_ref();
-        LittleEndian::read_u32(&data[field::FINGERPRINT])
+        le_bytes::read_u32(&data[field::FINGERPRINT])
     }
 
     /// Return the `probe_id` field
     #[inline]
     pub fn probe_id(&self) -> Result<ProbeId, BulkReportWireError> {
         let data = self.buffer.as_ref();
-        let raw_probe_id = LittleEndian::read_u32(&data[field::PROBE_ID]);
+        let raw_probe_id = le_bytes::read_u32(&data[field::PROBE_ID]);
         match ProbeId::new(raw_probe_id) {
             Some(id) => Ok(id),
             None => Err(BulkReportWireError::InvalidProbeId(raw_probe_id)),
@@ -155,14 +154,14 @@ impl<T: AsRef<[u8]>> BulkReport<T> {
     #[inline]
     pub fn n_log_bytes(&self) -> u32 {
         let data = self.buffer.as_ref();
-        LittleEndian::read_u32(&data[field::N_LOG_BYTES])
+        le_bytes::read_u32(&data[field::N_LOG_BYTES])
     }
 
     /// Return the `n_extension_bytes` field
     #[inline]
     pub fn n_extension_bytes(&self) -> u32 {
         let data = self.buffer.as_ref();
-        LittleEndian::read_u32(&data[field::N_EXT_BYTES])
+        le_bytes::read_u32(&data[field::N_EXT_BYTES])
     }
 }
 
@@ -181,28 +180,28 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> BulkReport<T> {
     #[inline]
     pub fn set_fingerprint(&mut self) {
         let data = self.buffer.as_mut();
-        LittleEndian::write_u32(&mut data[field::FINGERPRINT], Self::FINGERPRINT);
+        le_bytes::write_u32(&mut data[field::FINGERPRINT], Self::FINGERPRINT);
     }
 
     /// Set the `probe_id` field
     #[inline]
     pub fn set_probe_id(&mut self, value: ProbeId) {
         let data = self.buffer.as_mut();
-        LittleEndian::write_u32(&mut data[field::PROBE_ID], value.get_raw());
+        le_bytes::write_u32(&mut data[field::PROBE_ID], value.get_raw());
     }
 
     /// Set the `n_log_bytes` field
     #[inline]
     pub fn set_n_log_bytes(&mut self, value: u32) {
         let data = self.buffer.as_mut();
-        LittleEndian::write_u32(&mut data[field::N_LOG_BYTES], value);
+        le_bytes::write_u32(&mut data[field::N_LOG_BYTES], value);
     }
 
     /// Set the `n_extension_bytes` field
     #[inline]
     pub fn set_n_extension_bytes(&mut self, value: u32) {
         let data = self.buffer.as_mut();
-        LittleEndian::write_u32(&mut data[field::N_EXT_BYTES], value);
+        le_bytes::write_u32(&mut data[field::N_EXT_BYTES], value);
     }
 
     /// Return a mutable pointer to the payload

--- a/src/wire/bulk_report.rs
+++ b/src/wire/bulk_report.rs
@@ -1,0 +1,349 @@
+//! A wire protocol for representing Modality probe log reports in bulk form
+
+use byteorder::{ByteOrder, LittleEndian};
+
+/// Everything that can go wrong when attempting to interpret a bulk report
+/// from the wire representation
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum BulkReportWireError {
+    /// The fingerprint didn't match expectations
+    InvalidFingerprint,
+    /// There weren't enough bytes for a full header
+    MissingHeader,
+    /// There weren't enough payload bytes (based on
+    /// expectations from inspecting the header).
+    IncompletePayload,
+}
+
+/// A read/write wrapper around a bulk report buffer
+#[derive(Debug, Clone)]
+pub struct BulkReport<T: AsRef<[u8]>> {
+    buffer: T,
+}
+
+mod field {
+    type Field = ::core::ops::Range<usize>;
+    type Rest = ::core::ops::RangeFrom<usize>;
+
+    /// A magical (constant) value used as a hint about the
+    /// data encoded in this pile of bytes.
+    pub const FINGERPRINT: Field = 0..4;
+    /// A u32 representing the probe_id of the
+    /// Modality probe instance producing this report.
+    pub const PROBE_ID: Field = 4..8;
+    /// How many of the payload bytes are populated with log data?
+    pub const N_LOG_BYTES: Field = 8..12;
+    /// How many of the payload bytes are populated with extension data?
+    pub const N_EXT_BYTES: Field = 12..16;
+    /// The payload, consists of (in order):
+    /// * Log bytes: sequence of CompactLogItem ([u32])
+    /// * Extension bytes: sequence of u8
+    pub const PAYLOAD: Rest = 16..;
+}
+
+impl<T: AsRef<[u8]>> BulkReport<T> {
+    /// Bulk report fingerprint (EBLK)
+    pub const FINGERPRINT: u32 = 0x45_42_4C_4B;
+
+    /// Construct a bulk report from a byte buffer
+    pub fn new_unchecked(buffer: T) -> BulkReport<T> {
+        BulkReport { buffer }
+    }
+
+    /// Construct a bulk report from a byte buffer, with checks.
+    ///
+    /// A combination of:
+    /// * [new_unchecked](struct.BulkReport.html#method.new_unchecked)
+    /// * [check_len](struct.BulkReport.html#method.check_len)
+    /// * [check_fingerprint](struct.BulkReport.html#method.check_fingerprint)
+    /// * [check_payload_len](struct.BulkReport.html#method.check_payload_len)
+    pub fn new_checked(buffer: T) -> Result<BulkReport<T>, BulkReportWireError> {
+        let r = Self::new_unchecked(buffer);
+        r.check_len()?;
+        r.check_fingerprint()?;
+        r.check_payload_len()?;
+        Ok(r)
+    }
+
+    /// Ensure that no accessor method will panic if called.
+    ///
+    /// Returns `Err(BulkReportWireError::MissingHeader)` if the buffer
+    /// is too short.
+    pub fn check_len(&self) -> Result<(), BulkReportWireError> {
+        let len = self.buffer.as_ref().len();
+        if len < field::PAYLOAD.start {
+            Err(BulkReportWireError::MissingHeader)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Check for the expected fingerprint value.
+    ///
+    /// Returns `Err(BulkReportWireError::InvalidFingerprint)` if the fingerprint
+    /// does not match.
+    pub fn check_fingerprint(&self) -> Result<(), BulkReportWireError> {
+        if self.fingerprint() != Self::FINGERPRINT {
+            Err(BulkReportWireError::InvalidFingerprint)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Ensure the payload size is sufficient to hold bytes according to the header
+    /// fields `n_log_bytes` and `n_extension_bytes`.
+    ///
+    /// Returns `Err(BulkReportWireError::IncompletePayload)` if the buffer
+    /// is too short.
+    pub fn check_payload_len(&self) -> Result<(), BulkReportWireError> {
+        let n_log_bytes = self.n_log_bytes() as usize;
+        let n_extension_bytes = self.n_extension_bytes() as usize;
+        let len = self.buffer.as_ref().len();
+        if len < (field::PAYLOAD.start + n_log_bytes + n_extension_bytes) {
+            Err(BulkReportWireError::IncompletePayload)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Consumes the bulk report, returning the underlying buffer
+    pub fn into_inner(self) -> T {
+        self.buffer
+    }
+
+    /// Return the length of a bulk report header
+    pub fn header_len() -> usize {
+        field::PAYLOAD.start
+    }
+
+    /// Return the length of a buffer required to hold a bulk report
+    /// with a payload length of `n_log_bytes` + `n_extension_bytes`
+    pub fn buffer_len(n_log_bytes: usize, n_extension_bytes: usize) -> usize {
+        field::PAYLOAD.start + n_log_bytes + n_extension_bytes
+    }
+
+    /// Return the length of the bulk report payload
+    pub fn payload_len(&self) -> usize {
+        let n_log_bytes = self.n_log_bytes() as usize;
+        let n_extension_bytes = self.n_extension_bytes() as usize;
+        n_log_bytes + n_extension_bytes
+    }
+
+    /// Return the `fingerprint` field
+    #[inline]
+    pub fn fingerprint(&self) -> u32 {
+        let data = self.buffer.as_ref();
+        LittleEndian::read_u32(&data[field::FINGERPRINT])
+    }
+
+    /// Return the `probe_id` field
+    #[inline]
+    pub fn probe_id(&self) -> u32 {
+        let data = self.buffer.as_ref();
+        LittleEndian::read_u32(&data[field::PROBE_ID])
+    }
+
+    /// Return the `n_log_bytes` field
+    #[inline]
+    pub fn n_log_bytes(&self) -> u32 {
+        let data = self.buffer.as_ref();
+        LittleEndian::read_u32(&data[field::N_LOG_BYTES])
+    }
+
+    /// Return the `n_extension_bytes` field
+    #[inline]
+    pub fn n_extension_bytes(&self) -> u32 {
+        let data = self.buffer.as_ref();
+        LittleEndian::read_u32(&data[field::N_EXT_BYTES])
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> BulkReport<&'a T> {
+    /// Return a pointer to the payload
+    #[inline]
+    pub fn payload(&self) -> &'a [u8] {
+        let data = self.buffer.as_ref();
+        &data[field::PAYLOAD]
+    }
+}
+
+impl<T: AsRef<[u8]> + AsMut<[u8]>> BulkReport<T> {
+    /// Set the `fingerprint` field
+    #[inline]
+    pub fn set_fingerprint(&mut self, value: u32) {
+        let data = self.buffer.as_mut();
+        LittleEndian::write_u32(&mut data[field::FINGERPRINT], value);
+    }
+
+    /// Set the `probe_id` field
+    #[inline]
+    pub fn set_probe_id(&mut self, value: u32) {
+        let data = self.buffer.as_mut();
+        LittleEndian::write_u32(&mut data[field::PROBE_ID], value);
+    }
+
+    /// Set the `n_log_bytes` field
+    #[inline]
+    pub fn set_n_log_bytes(&mut self, value: u32) {
+        let data = self.buffer.as_mut();
+        LittleEndian::write_u32(&mut data[field::N_LOG_BYTES], value);
+    }
+
+    /// Set the `n_extension_bytes` field
+    #[inline]
+    pub fn set_n_extension_bytes(&mut self, value: u32) {
+        let data = self.buffer.as_mut();
+        LittleEndian::write_u32(&mut data[field::N_EXT_BYTES], value);
+    }
+
+    /// Return a mutable pointer to the payload
+    #[inline]
+    pub fn payload_mut(&mut self) -> &mut [u8] {
+        let data = self.buffer.as_mut();
+        &mut data[field::PAYLOAD]
+    }
+}
+
+impl<T: AsRef<[u8]>> AsRef<[u8]> for BulkReport<T> {
+    fn as_ref(&self) -> &[u8] {
+        self.buffer.as_ref()
+    }
+}
+
+impl<T: AsRef<[u8]> + AsMut<[u8]>> AsMut<[u8]> for BulkReport<T> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.buffer.as_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[rustfmt::skip]
+    static MSG_BYTES: [u8; 28] = [
+        // fingerprint
+        0x4B, 0x4C, 0x42, 0x45,
+        // probe_id: 1
+        0x01, 0x00, 0x00, 0x00,
+        // n_log_bytes: 8
+        0x08, 0x00, 0x00, 0x00,
+        // n_extension_bytes: 4
+        0x04, 0x00, 0x00, 0x00,
+        // payload
+        0x03, 0x00, 0x00, 0x00,
+        0x04, 0x00, 0x00, 0x00,
+        0x05, 0x00, 0x00, 0x00,
+    ];
+
+    #[rustfmt::skip]
+    static PAYLOAD_BYTES: [u8; 12] = [
+        0x03, 0x00, 0x00, 0x00,
+        0x04, 0x00, 0x00, 0x00,
+        0x05, 0x00, 0x00, 0x00,
+    ];
+
+    #[test]
+    fn header_len() {
+        assert_eq!(BulkReport::<&[u8]>::header_len(), 16);
+        let n_log_bytes = 12;
+        let n_ext_bytes = 14;
+        assert_eq!(
+            BulkReport::<&[u8]>::buffer_len(n_log_bytes, n_ext_bytes),
+            16 + 12 + 14
+        );
+    }
+
+    #[test]
+    fn construct() {
+        let mut bytes = [0xFF; 28];
+        let mut r = BulkReport::new_unchecked(&mut bytes[..]);
+        assert_eq!(r.check_len(), Ok(()));
+        r.set_fingerprint(BulkReport::<&[u8]>::FINGERPRINT);
+        r.set_probe_id(1);
+        r.set_n_log_bytes(8);
+        r.set_n_extension_bytes(4);
+        r.payload_mut().copy_from_slice(&PAYLOAD_BYTES[..]);
+        assert_eq!(r.check_fingerprint(), Ok(()));
+        assert_eq!(r.check_payload_len(), Ok(()));
+        assert_eq!(&r.into_inner()[..], &MSG_BYTES[..]);
+    }
+
+    #[test]
+    fn construct_with_extra() {
+        const EXTRA_JUNK_SIZE: usize = 7;
+        let mut bytes = [0xFF; 28 + EXTRA_JUNK_SIZE];
+        let mut r = BulkReport::new_unchecked(&mut bytes[..]);
+        assert_eq!(r.check_len(), Ok(()));
+        r.set_fingerprint(BulkReport::<&[u8]>::FINGERPRINT);
+        r.set_probe_id(1);
+        r.set_n_log_bytes(8);
+        r.set_n_extension_bytes(4);
+        assert_eq!(r.payload_len(), 8 + 4);
+        assert_eq!(r.payload_mut().len(), 8 + 4 + EXTRA_JUNK_SIZE);
+        let payload_len = r.payload_len();
+        (&mut r.payload_mut()[..payload_len]).copy_from_slice(&PAYLOAD_BYTES[..]);
+        assert_eq!(r.check_fingerprint(), Ok(()));
+        assert_eq!(r.check_payload_len(), Ok(()));
+        let msg_len = BulkReport::<&[u8]>::buffer_len(8, 4);
+        assert_eq!(&r.into_inner()[..msg_len], &MSG_BYTES[..]);
+    }
+
+    #[test]
+    fn deconstruct() {
+        let r = BulkReport::new_checked(&MSG_BYTES[..]).unwrap();
+        assert_eq!(r.fingerprint(), BulkReport::<&[u8]>::FINGERPRINT);
+        assert_eq!(r.probe_id(), 1);
+        assert_eq!(r.n_log_bytes(), 8);
+        assert_eq!(r.n_extension_bytes(), 4);
+        assert_eq!(r.payload_len(), 8 + 4);
+        assert_eq!(r.payload(), &PAYLOAD_BYTES[..]);
+        let n_log_bytes = r.n_log_bytes();
+        let (log_bytes, ext_bytes) = r.payload().split_at(n_log_bytes as usize);
+        assert_eq!(log_bytes, [0x03, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00]);
+        assert_eq!(ext_bytes, [0x05, 0x00, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn deconstruct_with_extra() {
+        const EXTRA_JUNK_SIZE: usize = 7;
+        let mut bytes = [0xFF; 28 + EXTRA_JUNK_SIZE];
+        assert_eq!(bytes.len(), MSG_BYTES.len() + EXTRA_JUNK_SIZE);
+        (&mut bytes[..28]).copy_from_slice(&MSG_BYTES[..]);
+        let r = BulkReport::new_checked(&bytes[..]).unwrap();
+        assert_eq!(r.fingerprint(), BulkReport::<&[u8]>::FINGERPRINT);
+        assert_eq!(r.probe_id(), 1);
+        assert_eq!(r.n_log_bytes(), 8);
+        assert_eq!(r.n_extension_bytes(), 4);
+        assert_eq!(r.payload_len(), 8 + 4);
+        assert_eq!(r.payload().len(), 8 + 4 + EXTRA_JUNK_SIZE);
+        let payload_len = r.payload_len();
+        assert_eq!(&r.payload()[..payload_len], &PAYLOAD_BYTES[..]);
+    }
+
+    #[test]
+    fn invalid_fingerprint() {
+        let bytes = [0xFF; 16];
+        let r = BulkReport::new_checked(&bytes[..]);
+        assert_eq!(r.unwrap_err(), BulkReportWireError::InvalidFingerprint);
+    }
+
+    #[test]
+    fn missing_header() {
+        let bytes = [0xFF; 16 - 1];
+        assert_eq!(bytes.len(), BulkReport::<&[u8]>::header_len() - 1);
+        let r = BulkReport::new_checked(&bytes[..]);
+        assert_eq!(r.unwrap_err(), BulkReportWireError::MissingHeader);
+    }
+
+    #[test]
+    fn incomplete_payload() {
+        let mut bytes = MSG_BYTES.clone();
+        let mut r = BulkReport::new_checked(&mut bytes[..]).unwrap();
+        r.set_n_log_bytes(8 + 1);
+        r.set_n_extension_bytes(4 + 1);
+        let bytes = r.into_inner();
+        let r = BulkReport::new_checked(&bytes[..]);
+        assert_eq!(r.unwrap_err(), BulkReportWireError::IncompletePayload);
+    }
+}

--- a/src/wire/causal_snapshot.rs
+++ b/src/wire/causal_snapshot.rs
@@ -1,0 +1,200 @@
+//! A wire protocol for representing Modality probe causal snaphots
+
+use crate::{wire::le_bytes, ProbeId};
+use core::mem::size_of;
+use static_assertions::const_assert_eq;
+
+/// Everything that can go wrong when attempting to interpret a causal snaphot
+/// from the wire representation
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum CausalSnapshotWireError {
+    /// There weren't enough bytes for a full causal snapshot
+    MissingBytes,
+    /// The probe id didn't follow the rules for being
+    /// a valid Modality probe-specifying ProbeId
+    InvalidProbeId(u32),
+}
+
+/// A read/write wrapper around a causal snaphot buffer
+#[derive(Debug, Clone)]
+pub struct CausalSnapshot<T: AsRef<[u8]>> {
+    buffer: T,
+}
+
+const_assert_eq!(size_of::<crate::CausalSnapshot>(), field::REST.start);
+
+mod field {
+    type Field = ::core::ops::Range<usize>;
+    type Rest = ::core::ops::RangeFrom<usize>;
+
+    /// LogicalClock.id
+    pub const PROBE_ID: Field = 0..4;
+    /// LogicalClock.count
+    pub const COUNT: Field = 4..8;
+    /// Reserved field
+    pub const RESERVED_0: Field = 8..10;
+    /// Reserved field
+    pub const RESERVED_1: Field = 10..12;
+    /// Remaining bytes
+    pub const REST: Rest = 12..;
+}
+
+impl<T: AsRef<[u8]>> CausalSnapshot<T> {
+    /// Construct a causal snaphot from a byte buffer
+    pub fn new_unchecked(buffer: T) -> CausalSnapshot<T> {
+        CausalSnapshot { buffer }
+    }
+
+    /// Construct a causal snaphot from a byte buffer, with checks.
+    ///
+    /// A combination of:
+    /// * [new_unchecked](struct.CausalSnapshot.html#method.new_unchecked)
+    /// * [check_len](struct.CausalSnapshot.html#method.check_len)
+    pub fn new(buffer: T) -> Result<CausalSnapshot<T>, CausalSnapshotWireError> {
+        let r = Self::new_unchecked(buffer);
+        r.check_len()?;
+        Ok(r)
+    }
+
+    /// Ensure that no accessor method will panic if called.
+    ///
+    /// Returns `Err(CausalSnapshotWireError::MissingBytes)` if the buffer
+    /// is too short.
+    pub fn check_len(&self) -> Result<(), CausalSnapshotWireError> {
+        let len = self.buffer.as_ref().len();
+        if len < field::REST.start {
+            Err(CausalSnapshotWireError::MissingBytes)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Consumes the causal snaphot, returning the underlying buffer
+    pub fn into_inner(self) -> T {
+        self.buffer
+    }
+
+    /// Return the length of a buffer required to hold a causal snaphot
+    pub fn buffer_len() -> usize {
+        field::REST.start
+    }
+
+    /// Return the `probe_id` field
+    #[inline]
+    pub fn probe_id(&self) -> Result<ProbeId, CausalSnapshotWireError> {
+        let data = self.buffer.as_ref();
+        let raw_probe_id = le_bytes::read_u32(&data[field::PROBE_ID]);
+        match ProbeId::new(raw_probe_id) {
+            Some(id) => Ok(id),
+            None => Err(CausalSnapshotWireError::InvalidProbeId(raw_probe_id)),
+        }
+    }
+
+    /// Return the `count` field
+    #[inline]
+    pub fn count(&self) -> u32 {
+        let data = self.buffer.as_ref();
+        le_bytes::read_u32(&data[field::COUNT])
+    }
+
+    /// Return the `reserved_0` field
+    #[inline]
+    pub fn reserved_0(&self) -> u16 {
+        let data = self.buffer.as_ref();
+        le_bytes::read_u16(&data[field::RESERVED_0])
+    }
+
+    /// Return the `reserved_1` field
+    #[inline]
+    pub fn reserved_1(&self) -> u16 {
+        let data = self.buffer.as_ref();
+        le_bytes::read_u16(&data[field::RESERVED_1])
+    }
+}
+
+impl<T: AsRef<[u8]> + AsMut<[u8]>> CausalSnapshot<T> {
+    /// Set the `probe_id` field
+    #[inline]
+    pub fn set_probe_id(&mut self, value: ProbeId) {
+        let data = self.buffer.as_mut();
+        le_bytes::write_u32(&mut data[field::PROBE_ID], value.get_raw());
+    }
+
+    /// Set the `count` field
+    #[inline]
+    pub fn set_count(&mut self, value: u32) {
+        let data = self.buffer.as_mut();
+        le_bytes::write_u32(&mut data[field::COUNT], value);
+    }
+
+    /// Set the `reserved_0` field
+    #[inline]
+    pub fn set_reserved_0(&mut self, value: u16) {
+        let data = self.buffer.as_mut();
+        le_bytes::write_u16(&mut data[field::RESERVED_0], value);
+    }
+
+    /// Set the `reserved_1` field
+    #[inline]
+    pub fn set_reserved_1(&mut self, value: u16) {
+        let data = self.buffer.as_mut();
+        le_bytes::write_u16(&mut data[field::RESERVED_1], value);
+    }
+}
+
+impl<T: AsRef<[u8]>> AsRef<[u8]> for CausalSnapshot<T> {
+    fn as_ref(&self) -> &[u8] {
+        self.buffer.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[rustfmt::skip]
+    static SNAPSHOT_BYTES: [u8; 12] = [
+        // probe_id: 1
+        0x01, 0x00, 0x00, 0x00,
+        // count: 2
+        0x02, 0x00, 0x00, 0x00,
+        // reserved_0: 3
+        0x03, 0x00,
+        // reserved_1: 4
+        0x04, 0x00,
+    ];
+
+    #[test]
+    fn buffer_len() {
+        assert_eq!(CausalSnapshot::<&[u8]>::buffer_len(), 12);
+    }
+
+    #[test]
+    fn construct() {
+        let mut bytes = [0xFF; 12];
+        let mut s = CausalSnapshot::new_unchecked(&mut bytes[..]);
+        assert_eq!(s.check_len(), Ok(()));
+        s.set_probe_id(ProbeId::new(1).unwrap());
+        s.set_count(2);
+        s.set_reserved_0(3);
+        s.set_reserved_1(4);
+        assert_eq!(&s.into_inner()[..], &SNAPSHOT_BYTES[..]);
+    }
+
+    #[test]
+    fn deconstruct() {
+        let s = CausalSnapshot::new(&SNAPSHOT_BYTES[..]).unwrap();
+        assert_eq!(s.probe_id().unwrap().get_raw(), 1);
+        assert_eq!(s.count(), 2);
+        assert_eq!(s.reserved_0(), 3);
+        assert_eq!(s.reserved_1(), 4);
+    }
+
+    #[test]
+    fn missing_bytes() {
+        let bytes = [0xFF; 12 - 1];
+        assert_eq!(bytes.len(), CausalSnapshot::<&[u8]>::buffer_len() - 1);
+        let s = CausalSnapshot::new(&bytes[..]);
+        assert_eq!(s.unwrap_err(), CausalSnapshotWireError::MissingBytes);
+    }
+}

--- a/src/wire/chunked_report.rs
+++ b/src/wire/chunked_report.rs
@@ -1,0 +1,469 @@
+//! A wire protocol for representing Modality probe log reports
+//! that are fragmented into multiple chunks due to sizing
+//! constraints
+
+use byteorder::{ByteOrder, LittleEndian};
+
+/// Everything that can go wrong when attempting to interpret a chunked report
+/// from the wire representation
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum ChunkedReportWireError {
+    /// The fingerprint didn't match expectations
+    InvalidFingerprint,
+    /// There weren't enough bytes for a full header
+    MissingHeader,
+    /// There weren't enough payload bytes (based on
+    /// expectations from inspecting the header).
+    IncompletePayload,
+    /// The header supplied a n_payload_bytes value
+    /// greater than the allowed maximum, `MAX_PAYLOAD_BYTES_PER_CHUNK`
+    TooManyPayloadBytes,
+}
+
+/// A read/write wrapper around a chunked report buffer
+#[derive(Debug, Clone)]
+pub struct ChunkedReport<T: AsRef<[u8]>> {
+    buffer: T,
+}
+
+mod field {
+    type Field = ::core::ops::Range<usize>;
+    type Rest = ::core::ops::RangeFrom<usize>;
+
+    /// A magical (constant) value used as a hint about the
+    /// data encoded in this pile of bytes.
+    pub const FINGERPRINT: Field = 0..4;
+    /// A u32 representing the probe_id of the
+    /// Modality probe instance producing this report.
+    pub const PROBE_ID: Field = 4..8;
+    /// A u16 representing the group of report chunks to which
+    /// this chunk belongs. Determined by the Modality probe instance.
+    /// Expected, but not guaranteed to be increasing
+    /// and wrapping-overflowing during the lifetime of an Modality probe
+    /// instance.
+    ///
+    /// Erring on the side of a large
+    /// number of these to support cases like:
+    ///   * a long-lasting partition from the report collector whilst reports
+    /// are archived for future sending
+    ///   * a very high report production cadence relative to the transmission cadence
+    pub const CHUNK_GROUP_ID: Field = 8..10;
+    /// In what ordinal position does this chunk's payload live relative to the other chunks.
+    pub const CHUNK_INDEX: Field = 10..12;
+    /// Does this chunk's payload contain log data (0x01) or extension data (0x02)?
+    pub const PAYLOAD_DATA_TYPE: usize = 12;
+    /// Is this chunk the last chunk in the report (0x01) or not (0x00)?
+    pub const IS_LAST_CHUNK: usize = 13;
+    /// Reserved for future enhancements and to make the payload 4-byte aligned
+    ///
+    /// Note that in general, the three bytes of data currently encoding
+    /// `payload_data_type`, `is_last_chunk`, and `reserved`, are ripe for future
+    /// compaction for bit-field use.
+    pub const RESERVED: usize = 14;
+    /// How many of the payload bytes are populated?
+    pub const N_CHUNK_PAYLOAD_BYTES: usize = 15;
+    /// The payload, consists of either log bytes, or extension bytes
+    pub const PAYLOAD: Rest = 16..;
+}
+
+impl<T: AsRef<[u8]>> ChunkedReport<T> {
+    /// Chunked report fingerprint (ECNK)
+    pub const FINGERPRINT: u32 = 0x45_43_4E_4B;
+
+    /// The size of a chunk in bytes
+    pub const MAX_CHUNK_BYTES: usize = 256;
+
+    /// The maximum number of payload bytes possibly populated
+    /// within a chunk.
+    pub const MAX_PAYLOAD_BYTES_PER_CHUNK: usize = 256 - field::PAYLOAD.start;
+
+    /// Construct a chunked report from a byte buffer
+    pub fn new_unchecked(buffer: T) -> ChunkedReport<T> {
+        ChunkedReport { buffer }
+    }
+
+    /// Construct a chunked report from a byte buffer, with checks.
+    ///
+    /// A combination of:
+    /// * [new_unchecked](struct.ChunkedReport.html#method.new_unchecked)
+    /// * [check_len](struct.ChunkedReport.html#method.check_len)
+    /// * [check_fingerprint](struct.ChunkedReport.html#method.check_fingerprint)
+    /// * [check_payload_len](struct.ChunkedReport.html#method.check_payload_len)
+    pub fn new_checked(buffer: T) -> Result<ChunkedReport<T>, ChunkedReportWireError> {
+        let r = Self::new_unchecked(buffer);
+        r.check_len()?;
+        r.check_fingerprint()?;
+        r.check_payload_len()?;
+        Ok(r)
+    }
+
+    /// Ensure that no accessor method will panic if called.
+    ///
+    /// Returns `Err(ChunkedReportWireError::MissingHeader)` if the buffer
+    /// is too short.
+    pub fn check_len(&self) -> Result<(), ChunkedReportWireError> {
+        let len = self.buffer.as_ref().len();
+        if len < field::PAYLOAD.start {
+            Err(ChunkedReportWireError::MissingHeader)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Check for the expected fingerprint value.
+    ///
+    /// Returns `Err(ChunkedReportWireError::InvalidFingerprint)` if the fingerprint
+    /// does not match.
+    pub fn check_fingerprint(&self) -> Result<(), ChunkedReportWireError> {
+        if self.fingerprint() != Self::FINGERPRINT {
+            Err(ChunkedReportWireError::InvalidFingerprint)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Ensure the payload size is sufficient to hold bytes according to the header
+    /// field `n_chunk_payload_bytes`.
+    ///
+    /// Returns `Err(ChunkedReportWireError::IncompletePayload)` if the buffer
+    /// is too short, and `Err(ChunkedReportWireError::TooManyPayloadBytes)` if
+    /// `n_chunk_payload_bytes` exceeds `MAX_PAYLOAD_BYTES_PER_CHUNK`.
+    pub fn check_payload_len(&self) -> Result<(), ChunkedReportWireError> {
+        let n_chunk_payload_bytes = self.n_chunk_payload_bytes() as usize;
+        let len = self.buffer.as_ref().len();
+        if len < (field::PAYLOAD.start + n_chunk_payload_bytes) {
+            Err(ChunkedReportWireError::IncompletePayload)
+        } else if n_chunk_payload_bytes > Self::MAX_PAYLOAD_BYTES_PER_CHUNK {
+            Err(ChunkedReportWireError::TooManyPayloadBytes)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Consumes the chunked report, returning the underlying buffer
+    pub fn into_inner(self) -> T {
+        self.buffer
+    }
+
+    /// Return the length of a chunked report header
+    pub fn header_len() -> usize {
+        field::PAYLOAD.start
+    }
+
+    /// Return the length of a buffer required to hold a chunked report
+    /// with a payload length of `n_chunk_payload_bytes`
+    pub fn buffer_len(n_chunk_payload_bytes: usize) -> usize {
+        field::PAYLOAD.start + n_chunk_payload_bytes
+    }
+
+    /// Return the length of the chunked report payload
+    pub fn payload_len(&self) -> usize {
+        self.n_chunk_payload_bytes() as usize
+    }
+
+    /// Return the `fingerprint` field
+    #[inline]
+    pub fn fingerprint(&self) -> u32 {
+        let data = self.buffer.as_ref();
+        LittleEndian::read_u32(&data[field::FINGERPRINT])
+    }
+
+    /// Return the `probe_id` field
+    #[inline]
+    pub fn probe_id(&self) -> u32 {
+        let data = self.buffer.as_ref();
+        LittleEndian::read_u32(&data[field::PROBE_ID])
+    }
+
+    /// Return the `chunk_group_id` field
+    #[inline]
+    pub fn chunk_group_id(&self) -> u16 {
+        let data = self.buffer.as_ref();
+        LittleEndian::read_u16(&data[field::CHUNK_GROUP_ID])
+    }
+
+    /// Return the `chunk_index` field
+    #[inline]
+    pub fn chunk_index(&self) -> u16 {
+        let data = self.buffer.as_ref();
+        LittleEndian::read_u16(&data[field::CHUNK_INDEX])
+    }
+
+    /// Return the `payload_data_type` field
+    #[inline]
+    pub fn payload_data_type(&self) -> u8 {
+        let data = self.buffer.as_ref();
+        data[field::PAYLOAD_DATA_TYPE]
+    }
+
+    /// Return the `is_last_chunk` field
+    #[inline]
+    pub fn is_last_chunk(&self) -> u8 {
+        let data = self.buffer.as_ref();
+        data[field::IS_LAST_CHUNK]
+    }
+
+    /// Return the `reserved` field
+    #[inline]
+    pub fn reserved(&self) -> u8 {
+        let data = self.buffer.as_ref();
+        data[field::RESERVED]
+    }
+
+    /// Return the `n_chunk_payload_bytes` field
+    #[inline]
+    pub fn n_chunk_payload_bytes(&self) -> u8 {
+        let data = self.buffer.as_ref();
+        data[field::N_CHUNK_PAYLOAD_BYTES]
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> ChunkedReport<&'a T> {
+    /// Return a pointer to the payload
+    #[inline]
+    pub fn payload(&self) -> &'a [u8] {
+        let data = self.buffer.as_ref();
+        &data[field::PAYLOAD]
+    }
+}
+
+impl<T: AsRef<[u8]> + AsMut<[u8]>> ChunkedReport<T> {
+    /// Set the `fingerprint` field
+    #[inline]
+    pub fn set_fingerprint(&mut self, value: u32) {
+        let data = self.buffer.as_mut();
+        LittleEndian::write_u32(&mut data[field::FINGERPRINT], value);
+    }
+
+    /// Set the `probe_id` field
+    #[inline]
+    pub fn set_probe_id(&mut self, value: u32) {
+        let data = self.buffer.as_mut();
+        LittleEndian::write_u32(&mut data[field::PROBE_ID], value);
+    }
+
+    /// Set the `chunk_group_id` field
+    #[inline]
+    pub fn set_chunk_group_id(&mut self, value: u16) {
+        let data = self.buffer.as_mut();
+        LittleEndian::write_u16(&mut data[field::CHUNK_GROUP_ID], value);
+    }
+
+    /// Set the `chunk_index` field
+    #[inline]
+    pub fn set_chunk_index(&mut self, value: u16) {
+        let data = self.buffer.as_mut();
+        LittleEndian::write_u16(&mut data[field::CHUNK_INDEX], value);
+    }
+
+    /// Set the `payload_data_type` field
+    #[inline]
+    pub fn set_payload_data_type(&mut self, value: u8) {
+        let data = self.buffer.as_mut();
+        data[field::PAYLOAD_DATA_TYPE] = value;
+    }
+
+    /// Set the `is_last_chunk` field
+    #[inline]
+    pub fn set_is_last_chunk(&mut self, value: u8) {
+        let data = self.buffer.as_mut();
+        data[field::IS_LAST_CHUNK] = value;
+    }
+
+    /// Set the `reserved` field
+    #[inline]
+    pub fn set_reserved(&mut self, value: u8) {
+        let data = self.buffer.as_mut();
+        data[field::RESERVED] = value;
+    }
+
+    /// Set the `n_chunk_payload_bytes` field
+    #[inline]
+    pub fn set_n_chunk_payload_bytes(&mut self, value: u8) {
+        let data = self.buffer.as_mut();
+        data[field::N_CHUNK_PAYLOAD_BYTES] = value;
+    }
+
+    /// Return a mutable pointer to the payload
+    #[inline]
+    pub fn payload_mut(&mut self) -> &mut [u8] {
+        let data = self.buffer.as_mut();
+        &mut data[field::PAYLOAD]
+    }
+}
+
+impl<T: AsRef<[u8]>> AsRef<[u8]> for ChunkedReport<T> {
+    fn as_ref(&self) -> &[u8] {
+        self.buffer.as_ref()
+    }
+}
+
+impl<T: AsRef<[u8]> + AsMut<[u8]>> AsMut<[u8]> for ChunkedReport<T> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.buffer.as_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[rustfmt::skip]
+    static MSG_BYTES: [u8; 28] = [
+        // fingerprint
+        0x4B, 0x4E, 0x43, 0x45,
+        // probe_id: 1
+        0x01, 0x00, 0x00, 0x00,
+        // chunk_group_id: 2
+        0x02, 0x00,
+        // chunk_index: 3,
+        0x03, 0x00,
+        // payload_data_type: 1
+        0x01,
+        // is_last_chunk: 0,
+        0x00,
+        // reserved: 0
+        0x00,
+        // n_chunk_payload_bytes: 12
+        0x0C,
+        // payload
+        0x03, 0x00, 0x00, 0x00,
+        0x04, 0x00, 0x00, 0x00,
+        0x05, 0x00, 0x00, 0x00,
+    ];
+
+    #[rustfmt::skip]
+    static PAYLOAD_BYTES: [u8; 12] = [
+        0x03, 0x00, 0x00, 0x00,
+        0x04, 0x00, 0x00, 0x00,
+        0x05, 0x00, 0x00, 0x00,
+    ];
+
+    #[test]
+    fn header_len() {
+        assert_eq!(ChunkedReport::<&[u8]>::header_len(), 16);
+        let n_chunk_payload_bytes = 12;
+        assert_eq!(
+            ChunkedReport::<&[u8]>::buffer_len(n_chunk_payload_bytes),
+            16 + 12
+        );
+    }
+
+    #[test]
+    fn construct() {
+        let mut bytes = [0xFF; 28];
+        let mut r = ChunkedReport::new_unchecked(&mut bytes[..]);
+        assert_eq!(r.check_len(), Ok(()));
+        r.set_fingerprint(ChunkedReport::<&[u8]>::FINGERPRINT);
+        r.set_probe_id(1);
+        r.set_chunk_group_id(2);
+        r.set_chunk_index(3);
+        r.set_payload_data_type(1);
+        r.set_is_last_chunk(0);
+        r.set_reserved(0);
+        r.set_n_chunk_payload_bytes(12);
+        r.payload_mut().copy_from_slice(&PAYLOAD_BYTES[..]);
+        assert_eq!(r.check_fingerprint(), Ok(()));
+        assert_eq!(r.check_payload_len(), Ok(()));
+        assert_eq!(&r.into_inner()[..], &MSG_BYTES[..]);
+    }
+
+    #[test]
+    fn construct_with_extra() {
+        const EXTRA_JUNK_SIZE: usize = 7;
+        let mut bytes = [0xFF; 28 + EXTRA_JUNK_SIZE];
+        let mut r = ChunkedReport::new_unchecked(&mut bytes[..]);
+        assert_eq!(r.check_len(), Ok(()));
+        r.set_fingerprint(ChunkedReport::<&[u8]>::FINGERPRINT);
+        r.set_probe_id(1);
+        r.set_chunk_group_id(2);
+        r.set_chunk_index(3);
+        r.set_payload_data_type(1);
+        r.set_is_last_chunk(0);
+        r.set_reserved(0);
+        r.set_n_chunk_payload_bytes(12);
+        assert_eq!(r.payload_len(), 12);
+        assert_eq!(r.payload_mut().len(), 12 + EXTRA_JUNK_SIZE);
+        let payload_len = r.payload_len();
+        (&mut r.payload_mut()[..payload_len]).copy_from_slice(&PAYLOAD_BYTES[..]);
+        assert_eq!(r.check_fingerprint(), Ok(()));
+        assert_eq!(r.check_payload_len(), Ok(()));
+        let msg_len = ChunkedReport::<&[u8]>::buffer_len(12);
+        assert_eq!(&r.into_inner()[..msg_len], &MSG_BYTES[..]);
+    }
+
+    #[test]
+    fn deconstruct() {
+        let r = ChunkedReport::new_checked(&MSG_BYTES[..]).unwrap();
+        assert_eq!(r.fingerprint(), ChunkedReport::<&[u8]>::FINGERPRINT);
+        assert_eq!(r.probe_id(), 1);
+        assert_eq!(r.chunk_group_id(), 2);
+        assert_eq!(r.chunk_index(), 3);
+        assert_eq!(r.payload_data_type(), 1);
+        assert_eq!(r.is_last_chunk(), 0);
+        assert_eq!(r.reserved(), 0);
+        assert_eq!(r.n_chunk_payload_bytes(), 12);
+        assert_eq!(r.payload_len(), 12);
+        assert_eq!(r.payload(), &PAYLOAD_BYTES[..]);
+    }
+
+    #[test]
+    fn deconstruct_with_extra() {
+        const EXTRA_JUNK_SIZE: usize = 7;
+        let mut bytes = [0xFF; 28 + EXTRA_JUNK_SIZE];
+        assert_eq!(bytes.len(), MSG_BYTES.len() + EXTRA_JUNK_SIZE);
+        (&mut bytes[..28]).copy_from_slice(&MSG_BYTES[..]);
+        let r = ChunkedReport::new_checked(&bytes[..]).unwrap();
+        assert_eq!(r.fingerprint(), ChunkedReport::<&[u8]>::FINGERPRINT);
+        assert_eq!(r.probe_id(), 1);
+        assert_eq!(r.chunk_group_id(), 2);
+        assert_eq!(r.chunk_index(), 3);
+        assert_eq!(r.payload_data_type(), 1);
+        assert_eq!(r.is_last_chunk(), 0);
+        assert_eq!(r.reserved(), 0);
+        assert_eq!(r.n_chunk_payload_bytes(), 12);
+        assert_eq!(r.payload_len(), 12);
+        assert_eq!(r.payload().len(), 12 + EXTRA_JUNK_SIZE);
+        let payload_len = r.payload_len();
+        assert_eq!(&r.payload()[..payload_len], &PAYLOAD_BYTES[..]);
+    }
+
+    #[test]
+    fn invalid_fingerprint() {
+        let bytes = [0xFF; 16];
+        let r = ChunkedReport::new_checked(&bytes[..]);
+        assert_eq!(r.unwrap_err(), ChunkedReportWireError::InvalidFingerprint);
+    }
+
+    #[test]
+    fn missing_header() {
+        let bytes = [0xFF; 16 - 1];
+        assert_eq!(bytes.len(), ChunkedReport::<&[u8]>::header_len() - 1);
+        let r = ChunkedReport::new_checked(&bytes[..]);
+        assert_eq!(r.unwrap_err(), ChunkedReportWireError::MissingHeader);
+    }
+
+    #[test]
+    fn incomplete_payload() {
+        let mut bytes = MSG_BYTES.clone();
+        let mut r = ChunkedReport::new_checked(&mut bytes[..]).unwrap();
+        assert!(MSG_BYTES.len() < (ChunkedReport::<&[u8]>::MAX_CHUNK_BYTES - 1));
+        r.set_n_chunk_payload_bytes(MSG_BYTES.len() as u8 + 1);
+        let bytes = r.into_inner();
+        let r = ChunkedReport::new_checked(&bytes[..]);
+        assert_eq!(r.unwrap_err(), ChunkedReportWireError::IncompletePayload);
+    }
+
+    #[test]
+    fn too_many_payload_bytes() {
+        const EXTRA_JUNK_SIZE: usize = 256;
+        let mut bytes = [0xFF; 28 + EXTRA_JUNK_SIZE];
+        assert_eq!(bytes.len(), MSG_BYTES.len() + EXTRA_JUNK_SIZE);
+        (&mut bytes[..28]).copy_from_slice(&MSG_BYTES[..]);
+        let mut r = ChunkedReport::new_checked(&mut bytes[..]).unwrap();
+        r.set_n_chunk_payload_bytes(ChunkedReport::<&[u8]>::MAX_PAYLOAD_BYTES_PER_CHUNK as u8 + 1);
+        let bytes = r.into_inner();
+        let r = ChunkedReport::new_checked(&bytes[..]);
+        assert_eq!(r.unwrap_err(), ChunkedReportWireError::TooManyPayloadBytes);
+    }
+}

--- a/src/wire/chunked_report.rs
+++ b/src/wire/chunked_report.rs
@@ -2,8 +2,7 @@
 //! that are fragmented into multiple chunks due to sizing
 //! constraints
 
-use crate::ProbeId;
-use byteorder::{ByteOrder, LittleEndian};
+use crate::{wire::le_bytes, ProbeId};
 use static_assertions::const_assert_ne;
 
 /// Everything that can go wrong when attempting to interpret a chunked report
@@ -198,14 +197,14 @@ impl<T: AsRef<[u8]>> ChunkedReport<T> {
     #[inline]
     pub fn fingerprint(&self) -> u32 {
         let data = self.buffer.as_ref();
-        LittleEndian::read_u32(&data[field::FINGERPRINT])
+        le_bytes::read_u32(&data[field::FINGERPRINT])
     }
 
     /// Return the `probe_id` field
     #[inline]
     pub fn probe_id(&self) -> Result<ProbeId, ChunkedReportWireError> {
         let data = self.buffer.as_ref();
-        let raw_probe_id = LittleEndian::read_u32(&data[field::PROBE_ID]);
+        let raw_probe_id = le_bytes::read_u32(&data[field::PROBE_ID]);
         match ProbeId::new(raw_probe_id) {
             Some(id) => Ok(id),
             None => Err(ChunkedReportWireError::InvalidProbeId(raw_probe_id)),
@@ -216,14 +215,14 @@ impl<T: AsRef<[u8]>> ChunkedReport<T> {
     #[inline]
     pub fn chunk_group_id(&self) -> u16 {
         let data = self.buffer.as_ref();
-        LittleEndian::read_u16(&data[field::CHUNK_GROUP_ID])
+        le_bytes::read_u16(&data[field::CHUNK_GROUP_ID])
     }
 
     /// Return the `chunk_index` field
     #[inline]
     pub fn chunk_index(&self) -> u16 {
         let data = self.buffer.as_ref();
-        LittleEndian::read_u16(&data[field::CHUNK_INDEX])
+        le_bytes::read_u16(&data[field::CHUNK_INDEX])
     }
 
     /// Return the `payload_data_type` field
@@ -274,28 +273,28 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> ChunkedReport<T> {
     #[inline]
     pub fn set_fingerprint(&mut self) {
         let data = self.buffer.as_mut();
-        LittleEndian::write_u32(&mut data[field::FINGERPRINT], Self::FINGERPRINT);
+        le_bytes::write_u32(&mut data[field::FINGERPRINT], Self::FINGERPRINT);
     }
 
     /// Set the `probe_id` field
     #[inline]
     pub fn set_probe_id(&mut self, value: ProbeId) {
         let data = self.buffer.as_mut();
-        LittleEndian::write_u32(&mut data[field::PROBE_ID], value.get_raw());
+        le_bytes::write_u32(&mut data[field::PROBE_ID], value.get_raw());
     }
 
     /// Set the `chunk_group_id` field
     #[inline]
     pub fn set_chunk_group_id(&mut self, value: u16) {
         let data = self.buffer.as_mut();
-        LittleEndian::write_u16(&mut data[field::CHUNK_GROUP_ID], value);
+        le_bytes::write_u16(&mut data[field::CHUNK_GROUP_ID], value);
     }
 
     /// Set the `chunk_index` field
     #[inline]
     pub fn set_chunk_index(&mut self, value: u16) {
         let data = self.buffer.as_mut();
-        LittleEndian::write_u16(&mut data[field::CHUNK_INDEX], value);
+        le_bytes::write_u16(&mut data[field::CHUNK_INDEX], value);
     }
 
     /// Set the `payload_data_type` field

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -1,9 +1,11 @@
 //! Wire protocols
 
 pub mod bulk_report;
+pub mod causal_snapshot;
 pub mod chunked_report;
 
 pub use bulk_report::*;
+pub use causal_snapshot::*;
 pub use chunked_report::*;
 
 mod le_bytes {

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -5,3 +5,115 @@ pub mod chunked_report;
 
 pub use bulk_report::*;
 pub use chunked_report::*;
+
+mod le_bytes {
+    // This pattern is mostly copied from
+    // https://github.com/BurntSushi/byteorder.
+    // We can't use that crate due to rust-lang/cargo#5730.
+    macro_rules! read_bytes {
+        ($ty:ty, $size:expr, $src:expr) => {{
+            use core::ptr::copy_nonoverlapping;
+            debug_assert!($size == ::core::mem::size_of::<$ty>());
+            debug_assert!($size <= $src.len());
+            let mut data: $ty = 0;
+            unsafe {
+                copy_nonoverlapping($src.as_ptr(), &mut data as *mut $ty as *mut u8, $size);
+            }
+            data.to_le()
+        }};
+    }
+
+    // This pattern is mostly copied from
+    // https://github.com/BurntSushi/byteorder
+    // We can't use that crate due to rust-lang/cargo#5730.
+    macro_rules! write_bytes {
+        ($ty:ty, $size:expr, $n:expr, $dst:expr) => {{
+            use core::ptr::copy_nonoverlapping;
+            debug_assert!($size <= $dst.len());
+            unsafe {
+                let bytes = *(&$n.to_le() as *const _ as *const [u8; $size]);
+                copy_nonoverlapping((&bytes).as_ptr(), $dst.as_mut_ptr(), $size);
+            }
+        }};
+    }
+
+    /// Reads a u16 from `bytes`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `bytes.len() < 2`.
+    #[inline]
+    pub fn read_u16(bytes: &[u8]) -> u16 {
+        read_bytes!(u16, 2, bytes)
+    }
+
+    /// Reads a u16 from `bytes`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `bytes.len() < 4`.
+    #[inline]
+    pub fn read_u32(bytes: &[u8]) -> u32 {
+        read_bytes!(u32, 4, bytes)
+    }
+
+    /// Writes a u16 `value` to `bytes`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `bytes.len() < 2`.
+    #[inline]
+    pub fn write_u16(bytes: &mut [u8], value: u16) {
+        write_bytes!(u16, 2, value, bytes);
+    }
+
+    /// Writes a u32 `value` to `bytes`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `bytes.len() < 4`.
+    #[inline]
+    pub fn write_u32(bytes: &mut [u8], value: u32) {
+        write_bytes!(u32, 4, value, bytes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn le_u16(
+            b0 in proptest::num::u8::ANY,
+            b1 in proptest::num::u8::ANY,
+        ) {
+            let expected_value = u16::from_le_bytes([b0, b1]);
+            let rbytes = [b0, b1];
+            let value = le_bytes::read_u16(&rbytes[0..2]);
+            assert_eq!(value, expected_value);
+            let mut wbytes = [!b0, !b1];
+            le_bytes::write_u16(&mut wbytes[0..2], expected_value);
+            assert_eq!(rbytes, wbytes);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn le_u32(
+            b0 in proptest::num::u8::ANY,
+            b1 in proptest::num::u8::ANY,
+            b2 in proptest::num::u8::ANY,
+            b3 in proptest::num::u8::ANY,
+        ) {
+            let expected_value = u32::from_le_bytes([b0, b1, b2, b3]);
+            let rbytes = [b0, b1, b2, b3];
+            let value = le_bytes::read_u32(&rbytes[0..4]);
+            assert_eq!(value, expected_value);
+            let mut wbytes = [!b0, !b1, !b2, !b3];
+            le_bytes::write_u32(&mut wbytes[0..4], expected_value);
+            assert_eq!(rbytes, wbytes);
+        }
+    }
+}

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -1,0 +1,7 @@
+//! Wire protocols
+
+pub mod bulk_report;
+pub mod chunked_report;
+
+pub use bulk_report::*;
+pub use chunked_report::*;


### PR DESCRIPTION
This commit replaces the fixed-size always-initialized wire structs
with read/write wrapper types over bytes.