### PR TITLE
Change tag macros

### DIFF
--- a/examples/event-recording.rs
+++ b/examples/event-recording.rs
@@ -23,8 +23,13 @@ fn main() {
     let remote = "127.0.0.1:2718";
 
     let mut storage = [0u8; 1024];
-    let probe = try_initialize_at!(&mut storage, PROBE_ID_FOO, "tags=example", "Example probe")
-        .expect("Could not initialize ModalityProbe");
+    let probe = try_initialize_at!(
+        &mut storage,
+        PROBE_ID_FOO,
+        tags!("example"),
+        "Example probe"
+    )
+    .expect("Could not initialize ModalityProbe");
 
     let mut loop_counter = 0;
     loop {
@@ -32,7 +37,7 @@ fn main() {
             probe,
             TOP_OF_THE_LOOP,
             "At the top of the loop",
-            "tags=example;my-tag"
+            tags!("example", "my-tag")
         )
         .expect("Could not record event");
 
@@ -41,7 +46,7 @@ fn main() {
             MOD10_CONDITION_EVENT,
             loop_counter % 10 == 0,
             "Loop counter % 10 event",
-            "tags=example"
+            tags!("example")
         )
         .expect("Could not record event");
 
@@ -64,7 +69,7 @@ fn main() {
                 probe,
                 REPORT_CREATED,
                 n_report_bytes as u32,
-                "tags=another tag",
+                tags!("another tag"),
                 "Report created"
             )
             .expect("could not record event with metadata");

--- a/modality-probe-capi/ctest/noop.c
+++ b/modality-probe-capi/ctest/noop.c
@@ -21,20 +21,20 @@ int main(void) {
             DEFAULT_PROBE_SIZE,
             DEFAULT_PROBE_ID,
             &g_probe,
-            "tags=my-tags;more tags",
+            MODALITY_TAGS("my-tags", "more tags"),
             "Description");
     assert(err == MODALITY_PROBE_ERROR_OK);
 
     err = MODALITY_PROBE_RECORD(
             g_probe,
             EVENT_A,
-            "tags=network;file-system;other-tags",
+            MODALITY_TAGS(network, file-system, "other-tags"),
             "Description");
     assert(err == MODALITY_PROBE_ERROR_OK);
     err = MODALITY_PROBE_RECORD(
             g_probe,
             EVENT_A,
-            "tags=network;file-system;other-tags");
+            MODALITY_TAGS(network, file-system, "other-tags"));
     assert(err == MODALITY_PROBE_ERROR_OK);
     err = MODALITY_PROBE_RECORD(
             g_probe,
@@ -57,13 +57,13 @@ int main(void) {
             g_probe,
             EVENT_A,
             my_data,
-            "tags=thing1;thing2");
+            MODALITY_TAGS("thing1", "thing2"));
     assert(err == MODALITY_PROBE_ERROR_OK);
     err = MODALITY_PROBE_RECORD_W_U8(
             g_probe,
             EVENT_A,
             my_data,
-            "tags=thing1;thing2",
+            MODALITY_TAGS("thing1", "thing2"),
             "Description");
     assert(err == MODALITY_PROBE_ERROR_OK);
 

--- a/modality-probe-capi/ctest/test.c
+++ b/modality-probe-capi/ctest/test.c
@@ -65,7 +65,7 @@ bool test_event_recording(void) {
             DEFAULT_PROBE_SIZE,
             DEFAULT_PROBE_ID,
             &t,
-            "tags=tag 1; tag 2",
+            MODALITY_TAGS(tag 1, tag 2),
             "desc");
     ERROR_CHECK(result, passed);
 
@@ -79,17 +79,17 @@ bool test_event_recording(void) {
     ERROR_CHECK(result, passed);
     result = modality_probe_record_event_with_payload(t, EVENT_A, 1);
     ERROR_CHECK(result, passed);
-    result = MODALITY_PROBE_RECORD(t, EVENT_A, (int8_t) 1, "tags=my-tag", "description");
+    result = MODALITY_PROBE_RECORD(t, EVENT_A, (int8_t) 1, MODALITY_TAGS("my-tag"), "description");
     ERROR_CHECK(result, passed);
-    result = MODALITY_PROBE_RECORD(t, EVENT_A, (int8_t) 1, "tags=my-tag");
+    result = MODALITY_PROBE_RECORD(t, EVENT_A, (int8_t) 1, MODALITY_TAGS(my-tag));
     ERROR_CHECK(result, passed);
     result = MODALITY_PROBE_RECORD_W_I8(t, EVENT_A, (int8_t) 1);
     ERROR_CHECK(result, passed);
     result = MODALITY_PROBE_RECORD_W_U8(t, EVENT_A, (uint8_t) 1, "more docs");
     ERROR_CHECK(result, passed);
-    result = MODALITY_PROBE_RECORD_W_I16(t, EVENT_A, (int16_t) 1, "tags=my tag");
+    result = MODALITY_PROBE_RECORD_W_I16(t, EVENT_A, (int16_t) 1, MODALITY_TAGS(my tag));
     ERROR_CHECK(result, passed);
-    result = MODALITY_PROBE_RECORD_W_U16(t, EVENT_A, (uint16_t) 1, "tags=a-tag", "desc");
+    result = MODALITY_PROBE_RECORD_W_U16(t, EVENT_A, (uint16_t) 1, MODALITY_TAGS("a-tag"), "desc");
     ERROR_CHECK(result, passed);
     result = MODALITY_PROBE_RECORD_W_I32(t, EVENT_A, (int32_t) 1, "some docs");
     ERROR_CHECK(result, passed);
@@ -99,7 +99,7 @@ bool test_event_recording(void) {
     ERROR_CHECK(result, passed);
     result = MODALITY_PROBE_RECORD_W_F32(t, EVENT_A, 1.23f, "my docs");
     ERROR_CHECK(result, passed);
-    result = MODALITY_PROBE_EXPECT(t, EVENT_A, 1 == 0, "my docs", "tags=severity.10");
+    result = MODALITY_PROBE_EXPECT(t, EVENT_A, 1 == 0, "my docs", MODALITY_TAGS("SEVERITY_10"));
     ERROR_CHECK(result, passed);
     modality_causal_snapshot snap_b;
     result = modality_probe_distribute_snapshot(t, &snap_b);

--- a/modality-probe-capi/include/probe.h
+++ b/modality-probe-capi/include/probe.h
@@ -134,6 +134,23 @@ typedef enum {
 } modality_probe_error;
 
 /*
+ * Modality probe tags specifying macro.
+ *
+ * This is a no-op macro used to expose tags to the CLI tooling.
+ *
+ * Note that tag strings must not contain any `(` or `)` characters.
+ *
+ * Example use:
+ * ```c
+ * MODALITY_TAGS(some tag)
+ *
+ * MODALITY_TAGS(tag-1, tag 2, "tag 3")
+ * ```
+ *
+ */
+#define MODALITY_TAGS(...)
+
+/*
  * Modality probe instance initializer macro.
  *
  * Used to expose probe information to the CLI tooling.
@@ -141,7 +158,7 @@ typedef enum {
  * Expands to call `modality_probe_initialize(dest, dest_size, id, probe)`.
  *
  * The trailing variadic macro arguments accept (in any order):
- * - A string for declaring tags: "tags=<tag>[;<tag>]"
+ * - Tags: MODALITY_TAGS(<tag>[,<tag>])
  * - A string for the probe description
  *
  */
@@ -156,7 +173,7 @@ typedef enum {
  * Expands to call `modality_probe_record_event(probe, event)`.
  *
  * The trailing variadic macro arguments accept (in any order):
- * - A string for declaring tags: "tags=<tag>[;<tag>]"
+ * - Tags: MODALITY_TAGS(<tag>[,<tag>])
  * - A string for the event description
  *
  */
@@ -171,7 +188,7 @@ typedef enum {
  * Expands to call `modality_probe_record_event_with_payload_<type>(probe, event)`.
  *
  * The trailing variadic macro arguments accept (in any order):
- * - A string for declaring tags: "tags=<tag>[;<tag>]"
+ * - Tags: MODALITY_TAGS(<tag>[,<tag>])
  * - A string for the event description
  *
  */
@@ -224,7 +241,7 @@ typedef enum {
  * Expands to call `modality_probe_record_event_with_payload_u32(probe, event, expression_outcome)`.
  *
  * The trailing variadic macro arguments accept (in any order):
- * - A string for declaring tags: "tags=<tag>[;<tag>]"
+ * - Tags: MODALITY_TAGS(<tag>[,<tag>])
  * - A string for the event description
  *
  */

--- a/modality-probe-cli/src/manifest_gen/c_parser.rs
+++ b/modality-probe-cli/src/manifest_gen/c_parser.rs
@@ -204,9 +204,11 @@ fn event_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
     let (input, _) = tag(tag_string.as_str())(input)?;
     let (input, _) = opt(line_ending)(input)?;
     let (input, _) = multispace0(input)?;
-    let (input, args) = delimited(char('('), is_not(")"), char(')'))(input)?;
+    let (input, _) = tag("(")(input)?;
+    let (input, args) = take_until(");")(input)
+        .map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
     let (input, _) =
-        tag(";")(input).map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
+        tag(");")(input).map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
     let (args, agent_instance) = variable_call_exp_arg(args)?;
     let expect_tags_or_desc = peek(variable_call_exp_arg)(args).is_ok();
     let (args, name) = if expect_tags_or_desc {
@@ -336,13 +338,17 @@ fn variable_call_exp_arg(input: Span) -> ParserResult<Span, String> {
 }
 
 fn multi_variable_call_exp_arg_literal(input: Span) -> ParserResult<Span, String> {
+    let (input, _) = comments_and_spacing(input)?;
     if input.fragment().is_empty() {
         return Err(nom::Err::Error(
             (input, nom::error::ErrorKind::ParseTo).into(),
         ));
     }
+    let (input, expect_tags) = peek(opt(tag("MODALITY_TAGS")))(input)?;
     let expect_another = peek(variable_call_exp_arg_literal)(input).is_ok();
-    let (input, arg) = if expect_another {
+    let (input, arg) = if expect_tags.is_some() {
+        modality_tags(input)?
+    } else if expect_another {
         variable_call_exp_arg_literal(input)?
     } else {
         rest_literal(input)?
@@ -365,10 +371,12 @@ fn parse_init_call_exp(input: Span) -> ParserResult<Span, ProbeMetadata> {
     let (input, _) = tag(tag_string.as_str())(input)?;
     let (input, _) = opt(line_ending)(input)?;
     let (input, _) = multispace0(input)?;
-    let (input, args) = delimited(char('('), is_not(")"), char(')'))(input)
-        .map_err(|e| convert_error(e, Error::Syntax(pos.into())))?;
+    let (input, _) = tag("(")(input)?;
+    let (input, args) = take_until(");")(input)
+        .map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
     let (input, _) =
-        tag(";")(input).map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
+        tag(");")(input).map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
+
     let (args, _storage) =
         variable_call_exp_arg(args).map_err(|e| convert_error(e, Error::Syntax(pos.into())))?;
     let (args, _storage_size) =
@@ -413,6 +421,35 @@ fn parse_init_call_exp(input: Span) -> ParserResult<Span, ProbeMetadata> {
             description,
         },
     ))
+}
+
+fn modality_tags(input: Span) -> ParserResult<Span, String> {
+    let (input, _) = comments_and_spacing(input)?;
+    let (input, pos) = position(input)?;
+    let (input, _) = tag("MODALITY_TAGS")(input)?;
+    let (input, args) = delimited(char('('), is_not(")"), char(')'))(input)
+        .map_err(|e| convert_error(e, Error::EmptyTags(pos.into())))?;
+    let (input, _) = opt(tag(","))(input)?;
+    let split: Vec<&str> = args.fragment().split(',').collect();
+    if split.is_empty() {
+        return Err(make_failure(input, Error::Syntax(pos.into())));
+    }
+    let mut tags = String::from("tags=");
+    for (idx, s) in split.iter().enumerate() {
+        let s = if !s.contains('"') {
+            format!("\"{}\"", s)
+        } else {
+            s.to_string()
+        };
+        let t =
+            truncate_and_trim(&s).map_err(|_| make_failure(input, Error::Syntax(pos.into())))?;
+        tags.push_str(&t);
+        if (split.len() > 1) && (idx < (split.len() - 1)) {
+            tags.push(';');
+        }
+    }
+    let tags = format!("\"{}\"", tags);
+    Ok((input, tags))
 }
 
 fn comments_and_spacing(input: Span) -> ParserResult<Span, ()> {
@@ -627,11 +664,11 @@ mod tests {
             STORAGE_SIZE,
             PROBE_ID_FOO,
             &g_agent,
-            "tags=my-tags;more tags",
+            MODALITY_TAGS(my-tags, more tags),
             "Description");
     assert(err == MODALITY_PROBE_ERROR_OK);
 
-    MODALITY_PROBE_INIT(storage, size, ID_BAR, t, "tags=my tag");
+    MODALITY_PROBE_INIT(storage, size, ID_BAR, t, MODALITY_TAGS(my tag));
 "#;
 
     const MIXED_EVENT_RECORDING_INPUT: &'static str = r#"
@@ -649,9 +686,9 @@ mod tests {
     MODALITY_PROBE_RECORD(
             probe, /* comments */
             EVENT_WRITE1,
-            "tags=network"); // more comments
+            MODALITY_TAGS(network)); // more comments
 
-    MODALITY_PROBE_RECORD(  probe, /* comments */ EVENT_WRITE2, "tags=network;file-system", "docs"); // more comments
+    MODALITY_PROBE_RECORD(  probe, /* comments */ EVENT_WRITE2, MODALITY_TAGS(network, file-system), "docs"); // more comments
 
     uint8_t status;
     const size_t err = MODALITY_PROBE_RECORD_W_U8(probe, EVENT_A, status);
@@ -676,7 +713,7 @@ mod tests {
         probe,
         EVENT_F,
     (uint16_t) *((uint16_t*) &mydata),
-    "tags=my tag"
+    MODALITY_TAGS(my tag)
     );
 
     const size_t err = MODALITY_PROBE_RECORD_W_U16(
@@ -684,18 +721,18 @@ mod tests {
         EVENT_G,
     (uint16_t) *((uint16_t*) &mydata),
     " docs ", /* Order of tags and docs doesn't matter */
-    "tags=thing1;thing2;my::namespace;tag with spaces" //docs
+    MODALITY_TAGS(thing1, thing2, my::namespace, "tag with spaces") // docs
     );
 
     err = MODALITY_PROBE_EXPECT(
             probe,
             EVENT_H,
             1 == 0, /* Arbitrary expression, evaluates to 0 (failure) or 1 (success) */
-            "tags=severity.1;another tag",
+            MODALITY_TAGS(SEVERITY_1, another tag),
             "Some description");
     assert(err == MODALITY_PROBE_ERROR_OK);
 
-    MODALITY_PROBE_EXPECT(probe, EVENT_I, *foo != (1 + bar), "tags=expectation;severity.2;network");
+    MODALITY_PROBE_EXPECT(probe, EVENT_I, *foo != (1 + bar), MODALITY_TAGS(expectation, SEVERITY_2, network));
 
     /* Special "expectation" tag is inserted"
     MODALITY_PROBE_EXPECT(probe, EVENT_J, 0 == 0);
@@ -746,7 +783,7 @@ mod tests {
                 },
                 ProbeMetadata {
                     name: "ID_BAR".to_string(),
-                    location: (1025, 41, 5).into(),
+                    location: (1034, 41, 5).into(),
                     tags: Some("my tag".to_string()),
                     description: None,
                 },
@@ -791,7 +828,7 @@ mod tests {
                     payload: None,
                     description: Some("docs".to_string()),
                     tags: Some("network;file-system".to_string()),
-                    location: (441, 18, 5).into(),
+                    location: (449, 18, 5).into(),
                 },
                 EventMetadata {
                     name: "EVENT_A".to_string(),
@@ -799,7 +836,7 @@ mod tests {
                     payload: Some((TypeHint::U8, "status").into()),
                     description: None,
                     tags: None,
-                    location: (599, 21, 24).into(),
+                    location: (616, 21, 24).into(),
                 },
                 EventMetadata {
                     name: "EVENT_B".to_string(),
@@ -807,7 +844,7 @@ mod tests {
                     payload: Some((TypeHint::U8, "status").into()),
                     description: Some("desc text here".to_string()),
                     tags: None,
-                    location: (675, 23, 24).into(),
+                    location: (692, 23, 24).into(),
                 },
                 EventMetadata {
                     name: "EVENT_C".to_string(),
@@ -815,7 +852,7 @@ mod tests {
                     payload: Some((TypeHint::I16, "(int16_t) data").into()),
                     description: None,
                     tags: None,
-                    location: (916, 32, 24).into(),
+                    location: (933, 32, 24).into(),
                 },
                 EventMetadata {
                     name: "EVENT_D".to_string(),
@@ -823,7 +860,7 @@ mod tests {
                     payload: Some((TypeHint::I16, "(int16_t) data").into()),
                     description: Some("docs".to_string()),
                     tags: None,
-                    location: (1001, 34, 24).into(),
+                    location: (1018, 34, 24).into(),
                 },
                 EventMetadata {
                     name: "EVENT_E".to_string(),
@@ -831,7 +868,7 @@ mod tests {
                     payload: Some((TypeHint::I8, "(int8_t) *((uint8_t*) &mydata)").into()),
                     description: None,
                     tags: None,
-                    location: (1094, 36, 24).into(),
+                    location: (1111, 36, 24).into(),
                 },
                 EventMetadata {
                     name: "EVENT_F".to_string(),
@@ -839,7 +876,7 @@ mod tests {
                     payload: Some((TypeHint::U16, "(uint16_t) *((uint16_t*) &mydata)").into()),
                     description: None,
                     tags: Some("my tag".to_string()),
-                    location: (1198, 39, 24).into(),
+                    location: (1215, 39, 24).into(),
                 },
                 EventMetadata {
                     name: "EVENT_G".to_string(),
@@ -847,23 +884,23 @@ mod tests {
                     payload: Some((TypeHint::U16, "(uint16_t) *((uint16_t*) &mydata)").into()),
                     description: Some("docs".to_string()),
                     tags: Some("thing1;thing2;my::namespace;tag with spaces".to_string()),
-                    location: (1347, 46, 24).into(),
+                    location: (1372, 46, 24).into(),
                 },
                 EventMetadata {
                     name: "EVENT_H".to_string(),
                     agent_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "1 == 0").into()),
                     description: Some("Some description".to_string()),
-                    tags: Some("expectation;severity.1;another tag".to_string()),
-                    location: (1585, 54, 11).into(),
+                    tags: Some("expectation;SEVERITY_1;another tag".to_string()),
+                    location: (1624, 54, 11).into(),
                 },
                 EventMetadata {
                     name: "EVENT_I".to_string(),
                     agent_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "*foo != (1 + bar)").into()),
                     description: None,
-                    tags: Some("expectation;severity.2;network".to_string()),
-                    location: (1861, 62, 5).into(),
+                    tags: Some("expectation;SEVERITY_2;network".to_string()),
+                    location: (1909, 62, 5).into(),
                 },
                 EventMetadata {
                     name: "EVENT_J".to_string(),
@@ -871,7 +908,7 @@ mod tests {
                     payload: Some((TypeHint::U32, "0 == 0").into()),
                     description: None,
                     tags: Some("expectation".to_string()),
-                    location: (2009, 65, 5).into(),
+                    location: (2067, 65, 5).into(),
                 },
             ])
         );
@@ -882,7 +919,6 @@ mod tests {
         let parser = CParser::default();
         let input = r#"
 const size_t err = MODALITY_PROBE_RECORD(g_probe, EVENT_READ)
-assert(err == MODALITY_PROBE_ERROR_OK);
 "#;
         let tokens = parser.parse_event_md(input);
         assert_eq!(tokens, Err(Error::MissingSemicolon((20, 2, 20).into())));
@@ -955,14 +991,14 @@ assert(err == MODALITY_PROBE_ERROR_OK);
     #[test]
     fn empty_event_tags_errors() {
         let parser = CParser::default();
-        let input = r#"MODALITY_PROBE_RECORD(probe, EVENT_A, "tags=", "desc");"#;
+        let input = r#"MODALITY_PROBE_RECORD(probe, EVENT_A, MODALITY_TAGS(), "desc");"#;
         let tokens = parser.parse_event_md(input);
-        assert_eq!(tokens, Err(Error::EmptyTags((0, 1, 1).into())));
-        let input = r#"MODALITY_PROBE_RECORD(probe, EVENT_A, "tags=");"#;
+        assert_eq!(tokens, Err(Error::EmptyTags((38, 1, 39).into())));
+        let input = r#"MODALITY_PROBE_RECORD(probe, EVENT_A, MODALITY_TAGS());"#;
         let tokens = parser.parse_event_md(input);
-        assert_eq!(tokens, Err(Error::EmptyTags((0, 1, 1).into())));
-        let input = r#"MODALITY_PROBE_RECORD_W_U32(probe, EVENT_A, 123, "desc", "tags=");"#;
+        assert_eq!(tokens, Err(Error::EmptyTags((38, 1, 39).into())));
+        let input = r#"MODALITY_PROBE_RECORD_W_U32(probe, EVENT_A, 123, "desc", MODALITY_TAGS());"#;
         let tokens = parser.parse_event_md(input);
-        assert_eq!(tokens, Err(Error::EmptyTags((0, 1, 1).into())));
+        assert_eq!(tokens, Err(Error::EmptyTags((57, 1, 58).into())));
     }
 }

--- a/modality-probe-cli/src/manifest_gen/rust_parser.rs
+++ b/modality-probe-cli/src/manifest_gen/rust_parser.rs
@@ -240,8 +240,6 @@ fn expect_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
     }
     let mut arg_vec: Vec<String> = Vec::new();
     let mut iter = iterator(args, multi_variable_call_exp_arg_literal);
-    //iter.for_each(|s| arg_vec.push(s));
-    //TODO
     iter.for_each(|s| {
         if !s.is_empty() {
             arg_vec.push(s)
@@ -391,8 +389,6 @@ fn event_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
     }
     let mut arg_vec: Vec<String> = Vec::new();
     let mut iter = iterator(args, multi_variable_call_exp_arg_literal);
-    //iter.for_each(|s| arg_vec.push(s));
-    // TODO
     iter.for_each(|s| {
         if !s.is_empty() {
             arg_vec.push(s)
@@ -453,8 +449,6 @@ fn event_try_with_payload_call_exp(input: Span) -> ParserResult<Span, EventMetad
     }
     let mut arg_vec: Vec<String> = Vec::new();
     let mut iter = iterator(args, multi_variable_call_exp_arg_literal);
-    //iter.for_each(|s| arg_vec.push(s));
-    //TODO
     iter.for_each(|s| {
         if !s.is_empty() {
             arg_vec.push(s)
@@ -690,8 +684,6 @@ fn parse_init_call_exp(input: Span) -> ParserResult<Span, ProbeMetadata> {
     }
     let mut tags_and_desc: Vec<String> = Vec::new();
     let mut iter = iterator(args, multi_variable_call_exp_arg_literal);
-    //iter.for_each(|s| tags_and_desc.push(s));
-    //TODO
     iter.for_each(|s| {
         if !s.is_empty() {
             tags_and_desc.push(s)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,19 +1,27 @@
+/// No-op macro used to specify one or more tags to be picked up
+/// by the CLI.
+///
+/// Note that tag strings must not contain any `(` or `)` characters.
+#[macro_export]
+macro_rules! tags {
+    ($tag:tt) => {};
+    ($tag:tt, $($more_tags:tt)+) => {};
+}
+
 /// Convenience macro that calls
 /// [ModalityProbe::initialize_at](struct.ModalityProbe.html#method.initialize_at).
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export]
 macro_rules! initialize_at {
     ($storage:expr, $probe_id:expr) => {
         ModalityProbe::initialize_at($storage, $probe_id)
     };
-    ($storage:expr, $probe_id:expr, $desc_or_tags:tt) => {
+    ($storage:expr, $probe_id:expr, $desc_or_tags:expr) => {
         ModalityProbe::initialize_at($storage, $probe_id)
     };
-    ($storage:expr, $probe_id:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {
+    ($storage:expr, $probe_id:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {
         ModalityProbe::initialize_at($storage, $probe_id)
     };
 }
@@ -23,17 +31,15 @@ macro_rules! initialize_at {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export]
 macro_rules! try_initialize_at {
     ($storage:expr, $probe_id:expr) => {
         ModalityProbe::try_initialize_at($storage, $probe_id)
     };
-    ($storage:expr, $probe_id:expr, $desc_or_tags:tt) => {
+    ($storage:expr, $probe_id:expr, $desc_or_tags:expr) => {
         ModalityProbe::try_initialize_at($storage, $probe_id)
     };
-    ($storage:expr, $probe_id:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {
+    ($storage:expr, $probe_id:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {
         ModalityProbe::try_initialize_at($storage, $probe_id)
     };
 }
@@ -43,17 +49,15 @@ macro_rules! try_initialize_at {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export]
 macro_rules! new_with_storage {
     ($storage:expr, $probe_id:expr) => {
         ModalityProbe::new_with_storage($storage, $probe_id)
     };
-    ($storage:expr, $probe_id:expr, $desc_or_tags:tt) => {
+    ($storage:expr, $probe_id:expr, $desc_or_tags:expr) => {
         ModalityProbe::new_with_storage($storage, $probe_id)
     };
-    ($storage:expr, $probe_id:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {
+    ($storage:expr, $probe_id:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {
         ModalityProbe::new_with_storage($storage, $probe_id)
     };
 }
@@ -63,17 +67,15 @@ macro_rules! new_with_storage {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export]
 macro_rules! record {
     ($probe:expr, $event:expr) => {
         $probe.record_event($event)
     };
-    ($probe:expr, $event:expr, $desc_or_tags:tt) => {
+    ($probe:expr, $event:expr, $desc_or_tags:expr) => {
         $probe.record_event($event)
     };
-    ($probe:expr, $event:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {
+    ($probe:expr, $event:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {
         $probe.record_event($event)
     };
 }
@@ -83,17 +85,15 @@ macro_rules! record {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export]
 macro_rules! try_record {
     ($probe:expr, $event:expr) => {
         $probe.try_record_event($event)
     };
-    ($probe:expr, $event:expr, $desc_or_tags:tt) => {
+    ($probe:expr, $event:expr, $desc_or_tags:expr) => {
         $probe.try_record_event($event)
     };
-    ($probe:expr, $event:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {
+    ($probe:expr, $event:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {
         $probe.try_record_event($event)
     };
 }
@@ -103,17 +103,15 @@ macro_rules! try_record {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_i8 {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
 }
@@ -123,17 +121,15 @@ macro_rules! record_w_i8 {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_u8 {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
 }
@@ -143,17 +139,15 @@ macro_rules! record_w_u8 {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_i16 {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
 }
@@ -163,17 +157,15 @@ macro_rules! record_w_i16 {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_u16 {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
 }
@@ -183,17 +175,15 @@ macro_rules! record_w_u16 {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_i32 {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
 }
@@ -203,17 +193,15 @@ macro_rules! record_w_i32 {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_u32 {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
 }
@@ -223,17 +211,15 @@ macro_rules! record_w_u32 {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_bool {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
 }
@@ -243,17 +229,15 @@ macro_rules! record_w_bool {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_f32 {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __record_with!($probe, $event, $payload)
     }};
 }
@@ -263,17 +247,15 @@ macro_rules! record_w_f32 {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_i8 {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
 }
@@ -283,17 +265,15 @@ macro_rules! try_record_w_i8 {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_u8 {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
 }
@@ -303,17 +283,15 @@ macro_rules! try_record_w_u8 {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_i16 {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
 }
@@ -323,17 +301,15 @@ macro_rules! try_record_w_i16 {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_u16 {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
 }
@@ -343,17 +319,15 @@ macro_rules! try_record_w_u16 {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_i32 {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
 }
@@ -363,17 +337,15 @@ macro_rules! try_record_w_i32 {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_u32 {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
 }
@@ -383,17 +355,15 @@ macro_rules! try_record_w_u32 {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_bool {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
 }
@@ -403,17 +373,15 @@ macro_rules! try_record_w_bool {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_f32 {
     ($probe:expr, $event:expr, $payload:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
-    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $payload:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __try_record_with!($probe, $event, $payload)
     }};
 }
@@ -423,17 +391,15 @@ macro_rules! try_record_w_f32 {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! expect {
     ($probe:expr, $event:expr, $expression:expr) => {{
         __record_with!($probe, $event, $expression)
     }};
-    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags:expr) => {{
         __record_with!($probe, $event, $expression)
     }};
-    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __record_with!($probe, $event, $expression)
     }};
 }
@@ -443,17 +409,15 @@ macro_rules! expect {
 ///
 /// The optional description and tags string arguments are only used
 /// by the CLI and compile away.
-///
-/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
 #[macro_export(local_inner_macros)]
 macro_rules! try_expect {
     ($probe:expr, $event:expr, $expression:expr) => {{
         __try_record_with!($probe, $event, $expression)
     }};
-    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags:tt) => {{
+    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags:expr) => {{
         __try_record_with!($probe, $event, $expression)
     }};
-    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
         __try_record_with!($probe, $event, $expression)
     }};
 }
@@ -541,7 +505,7 @@ mod tests {
         record!(
             probe,
             EventId::new(EVENT_D).unwrap(),
-            "tags=some-tag",
+            tags!("some-tag", "another tag"),
             "desc"
         );
 
@@ -549,53 +513,53 @@ mod tests {
             probe,
             EventId::new(EVENT_D).unwrap(),
             0,
-            "tags=some-tag",
+            tags!("some-tag"),
             "desc"
         );
         record_w_u8!(probe, EventId::new(EVENT_D).unwrap(), 0);
         record_w_i16!(probe, EventId::new(EVENT_D).unwrap(), 0, "desc");
-        record_w_u16!(probe, EventId::new(EVENT_D).unwrap(), 0, "tags=some-tag");
+        record_w_u16!(probe, EventId::new(EVENT_D).unwrap(), 0, tags!("some-tag"));
         record_w_i32!(
             probe,
             EventId::new(EVENT_D).unwrap(),
             0,
-            "tags=some-tag",
+            tags!("some-tag"),
             "desc"
         );
         record_w_u32!(
             probe,
             EventId::new(EVENT_D).unwrap(),
             0,
-            "tags=some-tag",
+            tags!("some-tag"),
             "desc"
         );
         record_w_bool!(
             probe,
             EventId::new(EVENT_D).unwrap(),
             true,
-            "tags=some-tag",
+            tags!("some-tag"),
             "desc"
         );
         record_w_f32!(
             probe,
             EventId::new(EVENT_D).unwrap(),
             0.0,
-            "tags=some-tag",
+            tags!("some-tag"),
             "desc"
         );
 
         try_record!(probe, EVENT_D).unwrap();
         try_record!(probe, EVENT_D, "desc").unwrap();
-        try_record!(probe, EVENT_D, "tags=some-tag", "desc").unwrap();
+        try_record!(probe, EVENT_D, tags!("some-tag"), "desc").unwrap();
 
         try_record_w_i8!(probe, EVENT_D, 0).unwrap();
         try_record_w_u8!(probe, EVENT_D, 0, "desc").unwrap();
-        try_record_w_i16!(probe, EVENT_D, 0, "tags=some-tag").unwrap();
-        try_record_w_u16!(probe, EVENT_D, 0, "tags=some-tag", "desc").unwrap();
-        try_record_w_i32!(probe, EVENT_D, 0, "tags=some-tag", "desc").unwrap();
-        try_record_w_u32!(probe, EVENT_D, 0, "tags=some-tag", "desc").unwrap();
-        try_record_w_bool!(probe, EVENT_D, false, "tags=some-tag", "desc").unwrap();
-        try_record_w_f32!(probe, EVENT_D, 0.0, "tags=some-tag", "desc").unwrap();
+        try_record_w_i16!(probe, EVENT_D, 0, tags!("some-tag")).unwrap();
+        try_record_w_u16!(probe, EVENT_D, 0, tags!("some-tag"), "desc").unwrap();
+        try_record_w_i32!(probe, EVENT_D, 0, tags!("some-tag"), "desc").unwrap();
+        try_record_w_u32!(probe, EVENT_D, 0, tags!("some-tag"), "desc").unwrap();
+        try_record_w_bool!(probe, EVENT_D, false, tags!("some-tag"), "desc").unwrap();
+        try_record_w_f32!(probe, EVENT_D, 0.0, tags!("some-tag"), "desc").unwrap();
 
         expect!(probe, EventId::new(EVENT_D).unwrap(), 1 == 0);
         expect!(probe, EventId::new(EVENT_D).unwrap(), 1_i8 == 0_i8, "desc");
@@ -603,7 +567,7 @@ mod tests {
             probe,
             EventId::new(EVENT_D).unwrap(),
             "s1" != "s2",
-            "tags=severity.1",
+            tags!("SEVERITY_1"),
             "desc"
         );
 
@@ -611,7 +575,7 @@ mod tests {
         try_expect!(probe, EVENT_D, 1 == (2 - 1), "desc").unwrap();
         let a = 1;
         let b = 2;
-        try_expect!(probe, EVENT_D, a != b, "desc", "tags=my expectation").unwrap();
+        try_expect!(probe, EVENT_D, a != b, "desc", tags!("my expect tag")).unwrap();
     }
 
     #[test]
@@ -620,12 +584,12 @@ mod tests {
         let mut storage = [0_u8; 1024];
         let _probe = initialize_at!(&mut storage, probe_id).unwrap();
         let _probe = initialize_at!(&mut storage, probe_id, "desc").unwrap();
-        let _probe = initialize_at!(&mut storage, probe_id, "desc", "tags=some-tag").unwrap();
+        let _probe = initialize_at!(&mut storage, probe_id, "desc", tags!("some-tag")).unwrap();
         let _probe = try_initialize_at!(&mut storage, 1).unwrap();
-        let _probe = try_initialize_at!(&mut storage, 1, "tags=some-tag").unwrap();
-        let _probe = try_initialize_at!(&mut storage, 1, "tags=some-tag", "desc").unwrap();
+        let _probe = try_initialize_at!(&mut storage, 1, tags!("some-tag", "another tag")).unwrap();
+        let _probe = try_initialize_at!(&mut storage, 1, tags!("some-tag"), "desc").unwrap();
         let _probe = new_with_storage!(&mut storage, probe_id).unwrap();
         let _probe = new_with_storage!(&mut storage, probe_id, "desc").unwrap();
-        let _probe = new_with_storage!(&mut storage, probe_id, "tags=some-tag", "desc").unwrap();
+        let _probe = new_with_storage!(&mut storage, probe_id, tags!("some-tag"), "desc").unwrap();
     }
 }


### PR DESCRIPTION
This commit changes the tag macros:
* In C, it's now `MODALITY_TAGS()`
* In Rust, it's now `tags!()`

Closes #147 