### PR TITLE
Change expectation tag casing, use probe naming instead of agent

### DIFF
--- a/modality-probe-cli/src/manifest_gen/c_parser.rs
+++ b/modality-probe-cli/src/manifest_gen/c_parser.rs
@@ -151,7 +151,7 @@ fn expect_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
         .map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
     let (input, _) =
         tag(");")(input).map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
-    let (args, agent_instance) = variable_call_exp_arg(args)?;
+    let (args, probe_instance) = variable_call_exp_arg(args)?;
     let (args, name) = variable_call_exp_arg(args)?;
     if !event_name_valid(&name) {
         return Err(make_failure(input, Error::Syntax(pos.into())));
@@ -188,7 +188,7 @@ fn expect_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
         input,
         EventMetadata {
             name,
-            agent_instance,
+            probe_instance,
             payload: Some((TypeHint::U32, expr).into()),
             description,
             tags,
@@ -209,7 +209,7 @@ fn event_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
         .map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
     let (input, _) =
         tag(");")(input).map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
-    let (args, agent_instance) = variable_call_exp_arg(args)?;
+    let (args, probe_instance) = variable_call_exp_arg(args)?;
     let expect_tags_or_desc = peek(variable_call_exp_arg)(args).is_ok();
     let (args, name) = if expect_tags_or_desc {
         variable_call_exp_arg(args)?
@@ -243,7 +243,7 @@ fn event_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
         input,
         EventMetadata {
             name,
-            agent_instance,
+            probe_instance,
             payload: None,
             description,
             tags,
@@ -273,7 +273,7 @@ fn event_with_payload_call_exp(input: Span) -> ParserResult<Span, EventMetadata>
         .map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
     let (input, _) =
         tag(");")(input).map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
-    let (args, agent_instance) = variable_call_exp_arg(args)?;
+    let (args, probe_instance) = variable_call_exp_arg(args)?;
     let (args, name) = variable_call_exp_arg(args)?;
     if !event_name_valid(&name) {
         return Err(make_failure(input, Error::Syntax(pos.into())));
@@ -321,7 +321,7 @@ fn event_with_payload_call_exp(input: Span) -> ParserResult<Span, EventMetadata>
         input,
         EventMetadata {
             name,
-            agent_instance,
+            probe_instance,
             payload: Some((type_hint, payload).into()),
             description,
             tags,
@@ -387,7 +387,7 @@ fn parse_init_call_exp(input: Span) -> ParserResult<Span, ProbeMetadata> {
         return Err(make_failure(input, Error::Syntax(pos.into())));
     }
     let expect_tags_or_desc = peek(variable_call_exp_arg)(args).is_ok();
-    let (args, _agent_instance) = if expect_tags_or_desc {
+    let (args, _probe_instance) = if expect_tags_or_desc {
         variable_call_exp_arg(args).map_err(|e| convert_error(e, Error::Syntax(pos.into())))?
     } else {
         rest_string(args).map_err(|e| convert_error(e, Error::Syntax(pos.into())))?
@@ -800,7 +800,7 @@ mod tests {
             Ok(vec![
                 EventMetadata {
                     name: "EVENT_READ1".to_string(),
-                    agent_instance: "g_probe".to_string(),
+                    probe_instance: "g_probe".to_string(),
                     payload: None,
                     description: None,
                     tags: None,
@@ -808,7 +808,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_READ2".to_string(),
-                    agent_instance: "g_probe".to_string(),
+                    probe_instance: "g_probe".to_string(),
                     payload: None,
                     description: Some("my docs".to_string()),
                     tags: None,
@@ -816,7 +816,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_WRITE1".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: None,
                     description: None,
                     tags: Some("network".to_string()),
@@ -824,7 +824,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_WRITE2".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: None,
                     description: Some("docs".to_string()),
                     tags: Some("network;file-system".to_string()),
@@ -832,7 +832,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_A".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::U8, "status").into()),
                     description: None,
                     tags: None,
@@ -840,7 +840,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_B".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::U8, "status").into()),
                     description: Some("desc text here".to_string()),
                     tags: None,
@@ -848,7 +848,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_C".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::I16, "(int16_t) data").into()),
                     description: None,
                     tags: None,
@@ -856,7 +856,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_D".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::I16, "(int16_t) data").into()),
                     description: Some("docs".to_string()),
                     tags: None,
@@ -864,7 +864,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_E".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::I8, "(int8_t) *((uint8_t*) &mydata)").into()),
                     description: None,
                     tags: None,
@@ -872,7 +872,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_F".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::U16, "(uint16_t) *((uint16_t*) &mydata)").into()),
                     description: None,
                     tags: Some("my tag".to_string()),
@@ -880,7 +880,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_G".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::U16, "(uint16_t) *((uint16_t*) &mydata)").into()),
                     description: Some("docs".to_string()),
                     tags: Some("thing1;thing2;my::namespace;tag with spaces".to_string()),
@@ -888,7 +888,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_H".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "1 == 0").into()),
                     description: Some("Some description".to_string()),
                     tags: Some("EXPECTATION;SEVERITY_1;another tag".to_string()),
@@ -896,7 +896,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_I".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "*foo != (1 + bar)").into()),
                     description: None,
                     tags: Some("EXPECTATION;SEVERITY_2;network".to_string()),
@@ -904,7 +904,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_J".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "0 == 0").into()),
                     description: None,
                     tags: Some("EXPECTATION".to_string()),

--- a/modality-probe-cli/src/manifest_gen/c_parser.rs
+++ b/modality-probe-cli/src/manifest_gen/c_parser.rs
@@ -177,11 +177,11 @@ fn expect_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
         if t.is_empty() {
             return Err(make_failure(input, Error::EmptyTags(pos.into())));
         }
-        if !t.contains("expectation") {
-            t.insert_str(0, "expectation;");
+        if !t.contains("EXPECTATION") {
+            t.insert_str(0, "EXPECTATION;");
         }
     } else {
-        tags = Some(String::from("expectation"));
+        tags = Some(String::from("EXPECTATION"));
     }
     let description = tags_and_desc.pop();
     Ok((
@@ -732,9 +732,9 @@ mod tests {
             "Some description");
     assert(err == MODALITY_PROBE_ERROR_OK);
 
-    MODALITY_PROBE_EXPECT(probe, EVENT_I, *foo != (1 + bar), MODALITY_TAGS(expectation, SEVERITY_2, network));
+    MODALITY_PROBE_EXPECT(probe, EVENT_I, *foo != (1 + bar), MODALITY_TAGS(EXPECTATION, SEVERITY_2, network));
 
-    /* Special "expectation" tag is inserted"
+    /* Special "EXPECTATION" tag is inserted"
     MODALITY_PROBE_EXPECT(probe, EVENT_J, 0 == 0);
 "#;
 
@@ -891,7 +891,7 @@ mod tests {
                     agent_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "1 == 0").into()),
                     description: Some("Some description".to_string()),
-                    tags: Some("expectation;SEVERITY_1;another tag".to_string()),
+                    tags: Some("EXPECTATION;SEVERITY_1;another tag".to_string()),
                     location: (1624, 54, 11).into(),
                 },
                 EventMetadata {
@@ -899,7 +899,7 @@ mod tests {
                     agent_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "*foo != (1 + bar)").into()),
                     description: None,
-                    tags: Some("expectation;SEVERITY_2;network".to_string()),
+                    tags: Some("EXPECTATION;SEVERITY_2;network".to_string()),
                     location: (1909, 62, 5).into(),
                 },
                 EventMetadata {
@@ -907,7 +907,7 @@ mod tests {
                     agent_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "0 == 0").into()),
                     description: None,
-                    tags: Some("expectation".to_string()),
+                    tags: Some("EXPECTATION".to_string()),
                     location: (2067, 65, 5).into(),
                 },
             ])

--- a/modality-probe-cli/src/manifest_gen/event_metadata.rs
+++ b/modality-probe-cli/src/manifest_gen/event_metadata.rs
@@ -13,7 +13,7 @@ pub struct Payload(pub TypeHint, pub String);
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct EventMetadata {
     pub name: String,
-    pub agent_instance: String,
+    pub probe_instance: String,
     pub payload: Option<Payload>,
     pub description: Option<String>,
     pub tags: Option<String>,

--- a/modality-probe-cli/src/manifest_gen/in_source_event.rs
+++ b/modality-probe-cli/src/manifest_gen/in_source_event.rs
@@ -89,7 +89,7 @@ mod tests {
             },
             metadata: EventMetadata {
                 name: "EVENT_A".to_string(),
-                agent_instance: "probe".to_string(),
+                probe_instance: "probe".to_string(),
                 payload: Some((TypeHint::U8, "mydata").into()),
                 description: None,
                 tags: None,

--- a/modality-probe-cli/src/manifest_gen/invocations.rs
+++ b/modality-probe-cli/src/manifest_gen/invocations.rs
@@ -798,7 +798,7 @@ mod tests {
             },
             metadata: EventMetadata {
                 name: "event_a".to_string(),
-                agent_instance: "probe".to_string(),
+                probe_instance: "probe".to_string(),
                 payload: None,
                 description: None,
                 tags: None,
@@ -825,7 +825,7 @@ mod tests {
             },
             metadata: EventMetadata {
                 name: "EVENT_A".to_string(),
-                agent_instance: "probe".to_string(),
+                probe_instance: "probe".to_string(),
                 payload: None,
                 description: None,
                 tags: None,
@@ -839,7 +839,7 @@ mod tests {
             },
             metadata: EventMetadata {
                 name: "EVENT_A".to_string(),
-                agent_instance: "probe".to_string(),
+                probe_instance: "probe".to_string(),
                 payload: None,
                 description: None,
                 tags: None,
@@ -866,7 +866,7 @@ mod tests {
             },
             metadata: EventMetadata {
                 name: "EVENT_A".to_string(),
-                agent_instance: "probe".to_string(),
+                probe_instance: "probe".to_string(),
                 payload: None,
                 description: None,
                 tags: None,
@@ -914,7 +914,7 @@ mod tests {
             },
             metadata: EventMetadata {
                 name: "EVENT_A".to_string(),
-                agent_instance: "probe".to_string(),
+                probe_instance: "probe".to_string(),
                 payload: None,
                 description: None,
                 tags: None,
@@ -962,7 +962,7 @@ mod tests {
             },
             metadata: EventMetadata {
                 name: "EVENT_A".to_string(),
-                agent_instance: "probe".to_string(),
+                probe_instance: "probe".to_string(),
                 payload: Some((TypeHint::U8, "mydata").into()),
                 description: None,
                 tags: None,
@@ -1010,7 +1010,7 @@ mod tests {
             },
             metadata: EventMetadata {
                 name: "EVENT_A".to_string(),
-                agent_instance: "probe".to_string(),
+                probe_instance: "probe".to_string(),
                 payload: None,
                 description: Some("desc".to_string()),
                 tags: Some("my-tag".to_string()),

--- a/modality-probe-cli/src/manifest_gen/rust_parser.rs
+++ b/modality-probe-cli/src/manifest_gen/rust_parser.rs
@@ -162,7 +162,7 @@ fn expect_try_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
         .map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
     let (input, _) =
         tag(";")(input).map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
-    let (args, agent_instance) = variable_call_exp_arg(args)?;
+    let (args, probe_instance) = variable_call_exp_arg(args)?;
     let (args, name) = variable_call_exp_arg(args)?;
     let name =
         reduce_namespace(&name).map_err(|_| make_failure(input, Error::Syntax(pos.into())))?;
@@ -208,7 +208,7 @@ fn expect_try_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
         input,
         EventMetadata {
             name,
-            agent_instance,
+            probe_instance,
             payload: Some((TypeHint::U32, expr).into()),
             description,
             tags,
@@ -226,7 +226,7 @@ fn expect_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
         .map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
     let (input, _) =
         tag(");")(input).map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
-    let (args, agent_instance) =
+    let (args, probe_instance) =
         variable_call_exp_arg(args).map_err(|e| convert_error(e, Error::Syntax(pos.into())))?;
     let (args, full_name) =
         variable_call_exp_arg(args).map_err(|e| convert_error(e, Error::Syntax(pos.into())))?;
@@ -284,7 +284,7 @@ fn expect_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
         input,
         EventMetadata {
             name,
-            agent_instance,
+            probe_instance,
             payload: Some((TypeHint::U32, expr).into()),
             description,
             tags,
@@ -303,7 +303,7 @@ fn event_try_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
         .map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
     let (input, _) =
         tag(";")(input).map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
-    let (args, agent_instance) = variable_call_exp_arg(args)?;
+    let (args, probe_instance) = variable_call_exp_arg(args)?;
     let expect_tags_or_desc = peek(variable_call_exp_arg)(args).is_ok();
     let (args, name) = if expect_tags_or_desc {
         variable_call_exp_arg(args)?
@@ -350,7 +350,7 @@ fn event_try_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
         input,
         EventMetadata {
             name,
-            agent_instance,
+            probe_instance,
             payload: None,
             description,
             tags,
@@ -368,7 +368,7 @@ fn event_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
         .map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
     let (input, _) =
         tag(");")(input).map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
-    let (args, agent_instance) =
+    let (args, probe_instance) =
         variable_call_exp_arg(args).map_err(|e| convert_error(e, Error::Syntax(pos.into())))?;
     let expect_tags_or_desc = peek(variable_call_exp_arg)(args).is_ok();
     let (args, full_name) = if expect_tags_or_desc {
@@ -417,7 +417,7 @@ fn event_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
         input,
         EventMetadata {
             name,
-            agent_instance,
+            probe_instance,
             payload: None,
             description,
             tags,
@@ -440,7 +440,7 @@ fn event_try_with_payload_call_exp(input: Span) -> ParserResult<Span, EventMetad
         .map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
     let (input, _) =
         tag(";")(input).map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
-    let (args, agent_instance) = variable_call_exp_arg(args)?;
+    let (args, probe_instance) = variable_call_exp_arg(args)?;
     let (args, name) = variable_call_exp_arg(args)?;
     let name =
         reduce_namespace(&name).map_err(|_| make_failure(input, Error::Syntax(pos.into())))?;
@@ -478,7 +478,7 @@ fn event_try_with_payload_call_exp(input: Span) -> ParserResult<Span, EventMetad
         input,
         EventMetadata {
             name,
-            agent_instance,
+            probe_instance,
             payload: Some((type_hint, payload).into()),
             description,
             tags,
@@ -501,7 +501,7 @@ fn event_with_payload_call_exp(input: Span) -> ParserResult<Span, EventMetadata>
         .map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
     let (input, _) =
         tag(");")(input).map_err(|e| convert_error(e, Error::MissingSemicolon(pos.into())))?;
-    let (args, agent_instance) =
+    let (args, probe_instance) =
         variable_call_exp_arg(args).map_err(|e| convert_error(e, Error::Syntax(pos.into())))?;
     let (args, full_name) =
         variable_call_exp_arg(args).map_err(|e| convert_error(e, Error::Syntax(pos.into())))?;
@@ -550,7 +550,7 @@ fn event_with_payload_call_exp(input: Span) -> ParserResult<Span, EventMetadata>
         input,
         EventMetadata {
             name,
-            agent_instance,
+            probe_instance,
             payload: Some((type_hint, payload).into()),
             description,
             tags,
@@ -1093,7 +1093,7 @@ mod tests {
             Ok(vec![
                 EventMetadata {
                     name: "EVENT_A".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: None,
                     description: Some("my text".to_string()),
                     tags: None,
@@ -1101,7 +1101,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_B".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: None,
                     description: Some("my text".to_string()),
                     tags: None,
@@ -1109,7 +1109,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_C".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: None,
                     description: None,
                     tags: None,
@@ -1117,7 +1117,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_D".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: None,
                     description: Some("my text".to_string()),
                     tags: None,
@@ -1125,7 +1125,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_E".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: None,
                     description: None,
                     tags: None,
@@ -1133,7 +1133,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_EAGAIN1".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: None,
                     description: None,
                     tags: None,
@@ -1141,7 +1141,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_EAGAIN2".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: None,
                     description: None,
                     tags: None,
@@ -1149,7 +1149,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_F".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: None,
                     description: None,
                     tags: Some("my tag;tag 2".to_string()),
@@ -1157,7 +1157,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_G".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: None,
                     description: Some("docs".to_string()),
                     tags: None,
@@ -1165,7 +1165,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_H".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "1_u32").into()),
                     description: None,
                     tags: None,
@@ -1173,7 +1173,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_I".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::F32, "1.234_f32").into()),
                     description: Some("desc".to_string()),
                     tags: Some("tag 1".to_string()),
@@ -1181,7 +1181,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_J".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::I8, "-2_i8").into()),
                     description: Some("desc".to_string()),
                     tags: Some("thing1;thing2;my::namespace;tag with spaces".to_string()),
@@ -1189,7 +1189,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_K".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "14 == (10 + 4)").into()),
                     description: Some("Some description".to_string()),
                     tags: Some("EXPECTATION;SEVERITY_1;another tag".to_string()),
@@ -1197,7 +1197,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_K".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "foo != bar").into()),
                     description: None,
                     tags: Some("EXPECTATION;SEVERITY_2;network".to_string()),
@@ -1205,7 +1205,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "EVENT_K".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "foo != bar").into()),
                     description: None,
                     tags: Some("EXPECTATION".to_string()),
@@ -1213,7 +1213,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "TOP_OF_THE_LOOP".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: None,
                     description: Some("At the top of the loop".to_string()),
                     tags: Some("example;my-tag".to_string()),
@@ -1221,7 +1221,7 @@ mod tests {
                 },
                 EventMetadata {
                     name: "MOD10_CONDITION_EVENT".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "loop_counter % 10 == 0").into()),
                     description: Some("Loop counter % 10 event".to_string()),
                     tags: Some("EXPECTATION;example".to_string()),
@@ -1353,7 +1353,7 @@ record_w_i8!(probe, EventId::try_from(events::more::EVENT_D).unwrap(), 1_i8, "de
             Ok(vec![
                 EventMetadata {
                     name: "EVENT_A".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: None,
                     description: Some("desc".to_string()),
                     tags: None,
@@ -1361,7 +1361,7 @@ record_w_i8!(probe, EventId::try_from(events::more::EVENT_D).unwrap(), 1_i8, "de
                 },
                 EventMetadata {
                     name: "EVENT_B".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: None,
                     description: Some("my text".to_string()),
                     tags: None,
@@ -1369,7 +1369,7 @@ record_w_i8!(probe, EventId::try_from(events::more::EVENT_D).unwrap(), 1_i8, "de
                 },
                 EventMetadata {
                     name: "EVENT_C".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "1_u32").into()),
                     description: None,
                     tags: None,
@@ -1377,7 +1377,7 @@ record_w_i8!(probe, EventId::try_from(events::more::EVENT_D).unwrap(), 1_i8, "de
                 },
                 EventMetadata {
                     name: "EVENT_D".to_string(),
-                    agent_instance: "probe".to_string(),
+                    probe_instance: "probe".to_string(),
                     payload: Some((TypeHint::I8, "1_i8").into()),
                     description: Some("desc".to_string()),
                     tags: None,

--- a/modality-probe-cli/src/manifest_gen/rust_parser.rs
+++ b/modality-probe-cli/src/manifest_gen/rust_parser.rs
@@ -197,11 +197,11 @@ fn expect_try_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
         if t.is_empty() {
             return Err(make_failure(input, Error::EmptyTags(pos.into())));
         }
-        if !t.contains("expectation") {
-            t.insert_str(0, "expectation;");
+        if !t.contains("EXPECTATION") {
+            t.insert_str(0, "EXPECTATION;");
         }
     } else {
-        tags = Some(String::from("expectation"));
+        tags = Some(String::from("EXPECTATION"));
     }
     let description = tags_and_desc.pop();
     Ok((
@@ -273,11 +273,11 @@ fn expect_call_exp(input: Span) -> ParserResult<Span, EventMetadata> {
         if t.is_empty() {
             return Err(make_failure(input, Error::EmptyTags(pos.into())));
         }
-        if !t.contains("expectation") {
-            t.insert_str(0, "expectation;");
+        if !t.contains("EXPECTATION") {
+            t.insert_str(0, "EXPECTATION;");
         }
     } else {
-        tags = Some(String::from("expectation"));
+        tags = Some(String::from("EXPECTATION"));
     }
     let description = tags_and_desc.pop();
     Ok((
@@ -1014,9 +1014,9 @@ mod tests {
         "Some description",
     );
 
-    try_expect!(probe, EVENT_K, foo != bar, tags!("expectation", "SEVERITY_2", "network")).unwrap();
+    try_expect!(probe, EVENT_K, foo != bar, tags!("EXPECTATION", "SEVERITY_2", "network")).unwrap();
 
-    /* Special "expectation" tag is inserted" */
+    /* Special "EXPECTATION" tag is inserted" */
     modality_probe::expect!(probe, EVENT_K.try_into()?, foo != bar);
 
     try_record!(
@@ -1192,7 +1192,7 @@ mod tests {
                     agent_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "14 == (10 + 4)").into()),
                     description: Some("Some description".to_string()),
-                    tags: Some("expectation;SEVERITY_1;another tag".to_string()),
+                    tags: Some("EXPECTATION;SEVERITY_1;another tag".to_string()),
                     location: (1270, 46, 5).into(),
                 },
                 EventMetadata {
@@ -1200,7 +1200,7 @@ mod tests {
                     agent_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "foo != bar").into()),
                     description: None,
-                    tags: Some("expectation;SEVERITY_2;network".to_string()),
+                    tags: Some("EXPECTATION;SEVERITY_2;network".to_string()),
                     location: (1447, 54, 5).into(),
                 },
                 EventMetadata {
@@ -1208,7 +1208,7 @@ mod tests {
                     agent_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "foo != bar").into()),
                     description: None,
-                    tags: Some("expectation".to_string()),
+                    tags: Some("EXPECTATION".to_string()),
                     location: (1614, 57, 21).into(),
                 },
                 EventMetadata {
@@ -1224,7 +1224,7 @@ mod tests {
                     agent_instance: "probe".to_string(),
                     payload: Some((TypeHint::U32, "loop_counter % 10 == 0").into()),
                     description: Some("Loop counter % 10 event".to_string()),
-                    tags: Some("expectation;example".to_string()),
+                    tags: Some("EXPECTATION;example".to_string()),
                     location: (1840, 67, 5).into(),
                 },
             ])


### PR DESCRIPTION
Based on #152 