### PR TITLE
Add component manifest generation

### DIFF
--- a/deep_clean.sh
+++ b/deep_clean.sh
@@ -12,7 +12,7 @@ cargo clean
 
 (
     cd examples
-    rm -f probes.csv events.csv generated_ids/mod.rs
+    rm -f Component.toml probes.csv events.csv generated_ids/mod.rs
 )
 
 (

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,2 +1,3 @@
 events.csv
 probes.csv
+Component.toml

--- a/examples/event-recording.rs
+++ b/examples/event-recording.rs
@@ -5,7 +5,7 @@
 //! ```
 //! modality-probe manifest-gen --output-path . ./
 //!
-//! modality-probe header-gen --lang Rust events.csv probes.csv --output-path generated_ids/mod.rs
+//! modality-probe header-gen --lang Rust --probes probes.csv --events events.csv --output-path generated_ids/mod.rs
 //! ```
 
 // The generated identifiers

--- a/examples/event-recording.rs
+++ b/examples/event-recording.rs
@@ -3,7 +3,7 @@
 //! Before building this example, run:
 //!
 //! ```
-//! modality-probe manifest-gen --events-csv-file events.csv --probes-csv-file probes.csv ./
+//! modality-probe manifest-gen --output-path . ./
 //!
 //! modality-probe header-gen --lang Rust events.csv probes.csv --output-path generated_ids/mod.rs
 //! ```

--- a/modality-probe-cli/Cargo.toml
+++ b/modality-probe-cli/Cargo.toml
@@ -33,13 +33,14 @@ itertools = "0.8.2"
 petgraph = "0.5.0"
 sha2 = "0.8"
 nom_locate = "2.0"
+toml = "0.5"
+sha3 = "0.9"
+hex = "0.4"
+derivative = "2.1"
+
 modality-probe-graph = { path = "../modality-probe-graph" }
-
-[dependencies.modality-probe]
-path = "../"
-
-[dependencies.util]
-path = "../util"
+modality-probe = { path = "../" }
+util = { path = "../util" }
 
 [dependencies.serde]
 version = "1"
@@ -54,6 +55,10 @@ features = []
 version = "0.4"
 features = ["serde"]
 
+[dependencies.uuid]
+version = "0.8"
+features = ["serde", "v4"]
+
 [dev-dependencies]
-proptest = "0.9"
 pretty_assertions = "0.6"
+tempfile = "3.1"

--- a/modality-probe-cli/src/completions.rs
+++ b/modality-probe-cli/src/completions.rs
@@ -2,6 +2,7 @@
 
 use structopt::{clap::Shell, StructOpt};
 
+mod component;
 mod error;
 mod events;
 mod export;

--- a/modality-probe-cli/src/component.rs
+++ b/modality-probe-cli/src/component.rs
@@ -1,0 +1,100 @@
+use crate::error::GracefulExit;
+use serde::{Deserialize, Serialize};
+use sha3::Sha3_256;
+use std::hash::Hash;
+use std::path::Path;
+use std::{fmt, fs, str};
+use uuid::Uuid;
+
+pub use sha3::Digest as ComponentHasherExt;
+
+pub type ComponentHasher = Sha3_256;
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct Component {
+    pub name: String,
+    pub uuid: ComponentUuId,
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "serde_hex")]
+    pub code_hash: Option<ComponentHash>,
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "serde_hex")]
+    pub instrumentation_hash: Option<ComponentHash>,
+}
+
+impl Component {
+    pub fn from_toml<P: AsRef<Path>>(path: P) -> Self {
+        let content =
+            &fs::read_to_string(path).unwrap_or_exit("Can't open component manifest file");
+        toml::from_str(content).unwrap_or_exit("Can't deserialize component")
+    }
+
+    pub fn write_toml<P: AsRef<Path>>(&self, path: P) {
+        let content = toml::to_string(self).unwrap_or_exit("Can't serialize component");
+        fs::write(path.as_ref(), &content).unwrap_or_exit("Can't create component manifest path");
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct ComponentUuId(pub Uuid);
+
+impl ComponentUuId {
+    pub fn new() -> Self {
+        ComponentUuId(Uuid::new_v4())
+    }
+
+    pub fn nil() -> Self {
+        ComponentUuId(Uuid::nil())
+    }
+}
+
+impl Default for ComponentUuId {
+    fn default() -> Self {
+        ComponentUuId::nil()
+    }
+}
+
+/// SHA3-256 hash
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct ComponentHash(pub [u8; 32]);
+
+impl From<[u8; 32]> for ComponentHash {
+    fn from(hash: [u8; 32]) -> Self {
+        ComponentHash(hash)
+    }
+}
+
+impl fmt::Display for ComponentHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        hex::encode(&self.0).fmt(f)
+    }
+}
+
+mod serde_hex {
+    use super::ComponentHash;
+    use serde::{de, Deserialize, Serialize};
+
+    pub fn serialize<S>(value: &Option<ComponentHash>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if let Some(hash) = value {
+            hex::encode(hash.0).serialize(serializer)
+        } else {
+            ().serialize(serializer)
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<ComponentHash>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: Option<&str> = Deserialize::deserialize(deserializer)?;
+        match s {
+            Some(s) => {
+                let mut out = [0u8; 32];
+                hex::decode_to_slice(s, &mut out).map_err(de::Error::custom)?;
+                Ok(Some(out.into()))
+            }
+            None => Ok(None),
+        }
+    }
+}

--- a/modality-probe-cli/src/lib.rs
+++ b/modality-probe-cli/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod component;
 pub mod error;
 pub mod events;
 pub mod export;

--- a/modality-probe-cli/src/manifest_gen/in_source_event.rs
+++ b/modality-probe-cli/src/manifest_gen/in_source_event.rs
@@ -1,4 +1,5 @@
 use crate::{
+    component::ComponentUuId,
     events::{Event, EventId},
     manifest_gen::{event_metadata::EventMetadata, file_path::FilePath},
 };
@@ -20,6 +21,7 @@ impl InSourceEvent {
 
     pub fn to_event(&self, id: EventId) -> Event {
         Event {
+            uuid: ComponentUuId::nil(),
             id,
             name: self.canonical_name(),
             description: self
@@ -98,6 +100,7 @@ mod tests {
         };
 
         let in_mf_event = Event {
+            uuid: ComponentUuId::nil(),
             id: EventId(1),
             name: "event_a".to_string(),
             description: String::from("stuff not in the src"),

--- a/modality-probe-cli/src/manifest_gen/in_source_probe.rs
+++ b/modality-probe-cli/src/manifest_gen/in_source_probe.rs
@@ -1,4 +1,5 @@
 use crate::{
+    component::ComponentUuId,
     manifest_gen::{file_path::FilePath, probe_metadata::ProbeMetadata},
     probes::{Probe, ProbeId},
 };
@@ -20,6 +21,7 @@ impl InSourceProbe {
 
     pub fn to_probe(&self, id: ProbeId) -> Probe {
         Probe {
+            uuid: ComponentUuId::nil(),
             id,
             name: self.canonical_name(),
             description: self
@@ -87,6 +89,7 @@ mod tests {
             },
         };
         let in_mf_probe = Probe {
+            uuid: ComponentUuId::nil(),
             id: ProbeId(1),
             name: "PROBE_ID_A".to_string(),
             description: String::from("not in src"),

--- a/modality-probe-cli/src/manifest_gen/invocations.rs
+++ b/modality-probe-cli/src/manifest_gen/invocations.rs
@@ -88,6 +88,7 @@ impl Invocations {
         let mut buffer = String::new();
         let mut code_hasher = ComponentHasher::new();
         for entry in WalkDir::new(&p)
+            .sort_by(|a, b| a.file_name().cmp(b.file_name()))
             .into_iter()
             .filter_entry(|e| !is_hidden(e))
             .filter_map(Result::ok)

--- a/modality-probe-cli/src/opts.rs
+++ b/modality-probe-cli/src/opts.rs
@@ -81,14 +81,16 @@ mod test {
                     "header-gen",
                     "--lang",
                     "Rust",
-                    "events.csv",
-                    "probes.csv"
+                    "--probes",
+                    "probes.csv",
+                    "--events",
+                    "events.csv"
                 ]
                 .iter()
             ),
             Opts::HeaderGen(HeaderGen {
-                events_csv_file: PathBuf::from("events.csv"),
-                probes_csv_file: PathBuf::from("probes.csv"),
+                probes: PathBuf::from("probes.csv"),
+                events: PathBuf::from("events.csv"),
                 lang: Lang::Rust,
                 include_guard_prefix: "MODALITY_PROBE".to_string(),
                 output_path: None,
@@ -101,16 +103,18 @@ mod test {
                     "header-gen",
                     "--lang",
                     "C",
-                    "events.csv",
+                    "--probes",
                     "probes.csv",
+                    "--events",
+                    "events.csv",
                     "--output-path",
                     "my_dir"
                 ]
                 .iter()
             ),
             Opts::HeaderGen(HeaderGen {
-                events_csv_file: PathBuf::from("events.csv"),
-                probes_csv_file: PathBuf::from("probes.csv"),
+                probes: PathBuf::from("probes.csv"),
+                events: PathBuf::from("events.csv"),
                 lang: Lang::C,
                 include_guard_prefix: "MODALITY_PROBE".to_string(),
                 output_path: Some(PathBuf::from("my_dir")),

--- a/modality-probe-cli/src/opts.rs
+++ b/modality-probe-cli/src/opts.rs
@@ -1,13 +1,13 @@
 use crate::{export::Export, header_gen::HeaderGen, manifest_gen::ManifestGen};
 use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, PartialEq, StructOpt)]
 #[structopt(
     name = "modality-probe",
     about = "Modality probe command line interface"
 )]
 pub enum Opts {
-    /// Generate event and probe id manifest files from probe macro invocations
+    /// Generate component, event and probe manifest files from probe macro invocations
     ManifestGen(ManifestGen),
 
     /// Generate Rust/C header files with event/probe id constants
@@ -15,4 +15,157 @@ pub enum Opts {
 
     /// Export a collected event log in a well-known graph format.
     Export(Export),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{export::GraphType, lang::Lang};
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
+
+    #[test]
+    fn parse_opts_manifest_gen() {
+        assert_eq!(
+            Opts::from_iter(["modality-probe", "manifest-gen", "/path",].iter()),
+            Opts::ManifestGen(ManifestGen {
+                lang: None,
+                event_id_offset: None,
+                probe_id_offset: None,
+                file_extensions: None,
+                component_name: String::from("component"),
+                output_path: PathBuf::from("component"),
+                regen_component_uuid: false,
+                source_path: PathBuf::from("/path"),
+            })
+        );
+        assert_eq!(
+            Opts::from_iter(
+                [
+                    "modality-probe",
+                    "manifest-gen",
+                    "--lang",
+                    "c",
+                    "--event-id-offset",
+                    "10",
+                    "--component-name",
+                    "my-comp",
+                    "--file-extension=c",
+                    "--regen-component-uuid",
+                    "--file-extension=cpp",
+                    "--output-path",
+                    "/out",
+                    "/path",
+                ]
+                .iter()
+            ),
+            Opts::ManifestGen(ManifestGen {
+                lang: Some(Lang::C),
+                event_id_offset: Some(10),
+                probe_id_offset: None,
+                file_extensions: Some(vec!["c".to_string(), "cpp".to_string()]),
+                component_name: String::from("my-comp"),
+                output_path: PathBuf::from("/out"),
+                regen_component_uuid: true,
+                source_path: PathBuf::from("/path"),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_opts_header_gen() {
+        assert_eq!(
+            Opts::from_iter(
+                [
+                    "modality-probe",
+                    "header-gen",
+                    "--lang",
+                    "Rust",
+                    "events.csv",
+                    "probes.csv"
+                ]
+                .iter()
+            ),
+            Opts::HeaderGen(HeaderGen {
+                events_csv_file: PathBuf::from("events.csv"),
+                probes_csv_file: PathBuf::from("probes.csv"),
+                lang: Lang::Rust,
+                include_guard_prefix: "MODALITY_PROBE".to_string(),
+                output_path: None,
+            })
+        );
+        assert_eq!(
+            Opts::from_iter(
+                [
+                    "modality-probe",
+                    "header-gen",
+                    "--lang",
+                    "C",
+                    "events.csv",
+                    "probes.csv",
+                    "--output-path",
+                    "my_dir"
+                ]
+                .iter()
+            ),
+            Opts::HeaderGen(HeaderGen {
+                events_csv_file: PathBuf::from("events.csv"),
+                probes_csv_file: PathBuf::from("probes.csv"),
+                lang: Lang::C,
+                include_guard_prefix: "MODALITY_PROBE".to_string(),
+                output_path: Some(PathBuf::from("my_dir")),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_opts_export() {
+        assert_eq!(
+            Opts::from_iter(
+                [
+                    "modality-probe",
+                    "export",
+                    "acyclic",
+                    "--events",
+                    "events.csv",
+                    "--probes",
+                    "probes.csv",
+                    "--report",
+                    "report.csv",
+                ]
+                .iter()
+            ),
+            Opts::Export(Export {
+                interactions_only: false,
+                events: PathBuf::from("events.csv"),
+                probes: PathBuf::from("probes.csv"),
+                report: PathBuf::from("report.csv"),
+                graph_type: GraphType::Acyclic,
+            })
+        );
+        assert_eq!(
+            Opts::from_iter(
+                [
+                    "modality-probe",
+                    "export",
+                    "cyclic",
+                    "--interactions-only",
+                    "--events",
+                    "events.csv",
+                    "--probes",
+                    "probes.csv",
+                    "--report",
+                    "report.csv",
+                ]
+                .iter()
+            ),
+            Opts::Export(Export {
+                interactions_only: true,
+                events: PathBuf::from("events.csv"),
+                probes: PathBuf::from("probes.csv"),
+                report: PathBuf::from("report.csv"),
+                graph_type: GraphType::Cyclic,
+            })
+        );
+    }
 }

--- a/modality-probe-cli/src/probes.rs
+++ b/modality-probe-cli/src/probes.rs
@@ -1,22 +1,40 @@
+use crate::{
+    component::{ComponentHasherExt, ComponentUuId},
+    error::GracefulExit,
+    exit_error,
+};
+use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs::File;
 use std::hash::Hash;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(
     Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, Deserialize, Serialize,
 )]
 pub struct ProbeId(pub u32);
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+#[derive(Derivative, Clone, Debug, Deserialize, Serialize)]
+#[derivative(PartialEq, Hash, PartialOrd)]
 pub struct Probe {
+    #[derivative(PartialEq = "ignore", PartialOrd = "ignore", Hash = "ignore")]
+    pub uuid: ComponentUuId,
     pub id: ProbeId,
     pub name: String,
     pub description: String,
     pub tags: String,
     pub file: String,
     pub line: String,
+}
+
+impl Probe {
+    // Excludes UUID, description, file and line
+    pub fn instrumentation_hash<H: ComponentHasherExt>(&self, state: &mut H) {
+        state.update(self.id.0.to_le_bytes());
+        state.update(self.name.as_bytes());
+        state.update(self.tags.as_bytes());
+    }
 }
 
 #[derive(Debug)]
@@ -26,14 +44,14 @@ pub struct Probes {
 }
 
 impl Probes {
-    pub fn from_csv(probes_csv_file: &PathBuf) -> Self {
-        let probes: Vec<Probe> = if probes_csv_file.exists() {
+    pub fn from_csv<P: AsRef<Path>>(path: P) -> Self {
+        let probes: Vec<Probe> = if path.as_ref().exists() {
             let mut reader = csv::Reader::from_reader(
-                File::open(probes_csv_file).expect("Can't open probes csv file"),
+                File::open(&path).unwrap_or_exit("Can't open probes manifest file"),
             );
             reader
                 .deserialize()
-                .map(|maybe_probe| maybe_probe.expect("Can't deserialize probe"))
+                .map(|maybe_probe| maybe_probe.unwrap_or_exit("Can't deserialize probe"))
                 .map(|mut t: Probe| {
                     t.name = t.name.to_uppercase();
                     t
@@ -44,23 +62,25 @@ impl Probes {
         };
 
         Probes {
-            path: probes_csv_file.clone(),
+            path: path.as_ref().to_path_buf(),
             probes,
         }
     }
 
-    pub fn write_csv(&self, probes_csv_file: &PathBuf) {
+    pub fn write_csv<P: AsRef<Path>>(&self, path: P) {
         let mut writer = csv::Writer::from_writer(
-            File::create(probes_csv_file).expect("Can't open probes csv file"),
+            File::create(&path).unwrap_or_exit("Can't create probes manifest file"),
         );
-        self.probes
-            .iter()
-            .for_each(|probe| writer.serialize(probe).expect("Can't serialize probe"));
-        writer.flush().expect("Can't flush probes writer");
+        self.probes.iter().for_each(|probe| {
+            writer
+                .serialize(probe)
+                .unwrap_or_exit("Can't serialize probe")
+        });
+        writer.flush().unwrap_or_exit("Can't flush probes writer");
     }
 
     pub fn next_available_probe_id(&self) -> u32 {
-        // Probe IDs start at 1
+        // Probe IDs are NonZeroU32, and therefore start at 1
         1 + self
             .probes
             .iter()
@@ -69,23 +89,34 @@ impl Probes {
             .unwrap_or(0)
     }
 
-    pub fn validate_nonzero_ids(&self) {
+    pub fn validate_ids(&self) {
         self.probes.iter().for_each(|probe| {
-            if probe.id.0 == 0 {
-                panic!("Probes CSV contains invalid ProbeId (0) \"{}\"", probe.name);
+            if modality_probe::ProbeId::new(probe.id.0).is_none() {
+                exit_error!(
+                    "probes",
+                    "Probes manifest contains a probe \"{}\" with an invalid ProbeId ({})",
+                    probe.name,
+                    probe.id.0,
+                );
             }
         });
     }
 
     pub fn validate_unique_ids(&self) {
         if !has_unique_elements(self.probes.iter().map(|probe| probe.id)) {
-            panic!("Probes CSV contains duplicate probe IDs");
+            exit_error!("probes", "Probes manifest contains duplicate probe IDs");
         }
     }
 
     pub fn validate_unique_names(&self) {
         if !has_unique_elements(self.probes.iter().map(|probe| probe.name.clone())) {
-            panic!("Probes CSV contains duplicate probe names");
+            exit_error!("probes", "Probes manifest contains duplicate probe names");
+        }
+    }
+
+    pub fn instrumentation_hash<H: ComponentHasherExt>(&self, state: &mut H) {
+        for p in self.probes.iter() {
+            p.instrumentation_hash(state);
         }
     }
 }

--- a/modality-probe-cli/tests/stable_uuid.rs
+++ b/modality-probe-cli/tests/stable_uuid.rs
@@ -53,6 +53,7 @@ fn stable_uuid() {
         output_path.to_str().unwrap(),
         src_path.to_str().unwrap(),
     ]);
+    println!("{:?}", out);
     assert!(out.status.success());
 
     assert!(component_path.exists());
@@ -61,7 +62,7 @@ fn stable_uuid() {
 
     // Hashes should be added, UUID is stable
     let component_content = fs::read_to_string(&component_path).unwrap();
-    println!("\n{}\n", component_content);
+    println!("{}", component_content);
     assert_eq!(component_content, COMPONENT_TOML);
 
     let out = run_cli(&vec![
@@ -80,14 +81,14 @@ fn stable_uuid() {
 
     // Nothing changes on successive runs
     let component_content = fs::read_to_string(&component_path).unwrap();
-    println!("\n{}\n", component_content);
+    println!("{}", component_content);
     assert_eq!(component_content, COMPONENT_TOML);
 }
 
 const COMPONENT_TOML: &'static str = r#"name = "my-component"
 uuid = "fa46ca95-c6fd-4020-b6a7-4323cfa084be"
-code_hash = "02265025b1ca3709f32f53a4b61fcc90d3a422bb888de316493d1c944bc1e202"
-instrumentation_hash = "bca64f05649ed0f0228bb4c17adf070e9d727852ee1f1c8c97dacf33cb618585"
+code_hash = "f4d29eefe0ec8137637fdc5e586539371d9784274aa3874b9c1b06ed3f2697cc"
+instrumentation_hash = "415871cc51857eb34fcce398a920fb5b3b43aa5a4a067d458938fe2f9ba7892a"
 "#;
 
 const COMPONENT_TOML_WO_HASHES: &'static str = r#"name = "my-component"

--- a/modality-probe-cli/tests/stable_uuid.rs
+++ b/modality-probe-cli/tests/stable_uuid.rs
@@ -1,0 +1,132 @@
+use pretty_assertions::assert_eq;
+use std::fs::{self, File};
+use std::io::Write;
+
+mod test_helpers;
+use test_helpers::run_cli;
+
+#[test]
+fn stable_uuid() {
+    let root_dir = tempfile::tempdir().unwrap();
+    let root_path = root_dir.path().to_owned();
+
+    let output_path = root_path.join("out");
+    fs::create_dir(&output_path).unwrap();
+
+    let component_path = output_path.join("Component.toml");
+    let events_path = output_path.join("events.csv");
+    let probes_path = output_path.join("probes.csv");
+
+    let src_path = root_path.join("src");
+    fs::create_dir(&src_path).unwrap();
+
+    let c_src_path = src_path.join("main.c");
+    let rust_src_path = src_path.join("main.rs");
+
+    // Scope this so the files get immediately closed; this matters on windows
+    {
+        let mut c_src_file = File::create(&c_src_path).unwrap();
+        c_src_file.write_all(C_SRC.as_bytes()).unwrap();
+        c_src_file.sync_all().unwrap();
+
+        let mut rust_src_file = File::create(&rust_src_path).unwrap();
+        rust_src_file.write_all(RUST_SRC.as_bytes()).unwrap();
+        rust_src_file.sync_all().unwrap();
+
+        let mut comp_file = File::create(&component_path).unwrap();
+        comp_file
+            .write_all(COMPONENT_TOML_WO_HASHES.as_bytes())
+            .unwrap();
+        comp_file.sync_all().unwrap();
+    }
+
+    // Start with a component file without hashes
+    let out = run_cli(&vec![
+        "manifest-gen",
+        "--file-extension",
+        "c",
+        "--file-extension",
+        "rs",
+        "--component-name",
+        "my-component",
+        "--output-path",
+        output_path.to_str().unwrap(),
+        src_path.to_str().unwrap(),
+    ]);
+    assert!(out.status.success());
+
+    assert!(component_path.exists());
+    assert!(events_path.exists());
+    assert!(probes_path.exists());
+
+    // Hashes should be added, UUID is stable
+    let component_content = fs::read_to_string(&component_path).unwrap();
+    println!("\n{}\n", component_content);
+    assert_eq!(component_content, COMPONENT_TOML);
+
+    let out = run_cli(&vec![
+        "manifest-gen",
+        "--file-extension",
+        "c",
+        "--file-extension",
+        "rs",
+        "--component-name",
+        "my-component",
+        "--output-path",
+        output_path.to_str().unwrap(),
+        src_path.to_str().unwrap(),
+    ]);
+    assert!(out.status.success());
+
+    // Nothing changes on successive runs
+    let component_content = fs::read_to_string(&component_path).unwrap();
+    println!("\n{}\n", component_content);
+    assert_eq!(component_content, COMPONENT_TOML);
+}
+
+const COMPONENT_TOML: &'static str = r#"name = "my-component"
+uuid = "fa46ca95-c6fd-4020-b6a7-4323cfa084be"
+code_hash = "02265025b1ca3709f32f53a4b61fcc90d3a422bb888de316493d1c944bc1e202"
+instrumentation_hash = "bca64f05649ed0f0228bb4c17adf070e9d727852ee1f1c8c97dacf33cb618585"
+"#;
+
+const COMPONENT_TOML_WO_HASHES: &'static str = r#"name = "my-component"
+uuid = "fa46ca95-c6fd-4020-b6a7-4323cfa084be"
+"#;
+
+const C_SRC: &'static str = r#"
+size_t err = MODALITY_PROBE_INIT(
+        &probe_storage[0],
+        PROBE_STORAGE_SIZE,
+        PROBE_ID_A,
+        &probe,
+        MODALITY_TAGS("my-tags", "more tags"),
+        "Description");
+assert(err == MODALITY_PROBE_ERROR_OK);
+
+size_t err = MODALITY_PROBE_RECORD_W_U8(
+        probe,
+        MY_EVENT_A,
+        my_data,
+        MODALITY_TAGS("tag 1", "tag 2", "tag 3"));
+assert(err == MODALITY_PROBE_ERROR_OK);
+"#;
+
+const RUST_SRC: &'static str = r#"
+let probe = try_initialize_at!(
+    &mut storage,
+    PROBE_ID_B,
+    tags!("some tag"),
+    "Description"
+)
+.expect("Could not initialize ModalityProbe");
+
+try_expect!(
+    probe,
+    MY_EVENT_B,
+    true != false,
+    "Description",
+    tags!("a tag")
+)
+.expect("Could not record event");
+"#;

--- a/modality-probe-cli/tests/test_helpers.rs
+++ b/modality-probe-cli/tests/test_helpers.rs
@@ -1,0 +1,31 @@
+use std::path::PathBuf;
+use std::process;
+use std::process::Command;
+
+pub fn run_cli(args: &Vec<&str>) -> process::Output {
+    let mut cli_command = Command::new(built_executable_path("modality-probe"));
+    cli_command.env("RUST_BACKTRACE", "1").args(args);
+    cli_command.output().unwrap()
+}
+
+fn get_target_dir() -> PathBuf {
+    let bin = std::env::current_exe().expect("exe path");
+    let mut target_dir = PathBuf::from(bin.parent().expect("bin parent"));
+    while target_dir.file_name() != Some(std::ffi::OsStr::new("target")) {
+        target_dir.pop();
+    }
+    target_dir
+}
+
+fn built_executable_path(name: &str) -> PathBuf {
+    let program_path =
+        get_target_dir()
+            .join("debug")
+            .join(format!("{}{}", name, std::env::consts::EXE_SUFFIX));
+
+    program_path.canonicalize().expect(&format!(
+        "Cannot resolve {} at {:?}",
+        name,
+        program_path.display()
+    ))
+}

--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,7 @@ set -ex
     cd examples/
     rm -f events.csv probes.csv
     mkdir -p generated_ids/
-    cargo run -p modality-probe-cli -- manifest-gen --events-csv-file events.csv --probes-csv-file probes.csv ./
+    cargo run -p modality-probe-cli -- manifest-gen --output-path . ./
     cargo run -p modality-probe-cli -- header-gen --lang Rust events.csv probes.csv --output-path generated_ids/mod.rs
 )
 

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ set -ex
     rm -f events.csv probes.csv
     mkdir -p generated_ids/
     cargo run -p modality-probe-cli -- manifest-gen --output-path . ./
-    cargo run -p modality-probe-cli -- header-gen --lang Rust events.csv probes.csv --output-path generated_ids/mod.rs
+    cargo run -p modality-probe-cli -- header-gen --lang Rust --probes probes.csv --events events.csv --output-path generated_ids/mod.rs
 )
 
 cargo build --all


### PR DESCRIPTION
This commit adds component manifest generation to the `manifest-gen` subcommand of the CLI.

* Layout
  - `Component.toml`
  - `events.csv`
  - `probes.csv`

The component manifest, `Component.toml`, consist of:

```toml
name = "<component-name>"
uuid = "<128-bit hyphenated UUID stored as a hex string"
code_hash = "<SHA-3-256 hash of the scanned source code>"
instrumentation_hash = "<SHA-3-256 hash of the instrumentation information>"
```

The component UUID is intended to be stable.
It will be generated when creating a new component manifest file
or per user request via `--regen-component-uuid`.

The instrumentation hash is computed from the probe and event
manifests; excluding the component UUID, description, file and line fields.

When hand-writing a component manifest, the `code_hash`
and `instrumentation_hash` may be omitted, as the CLI will automatically
generate them as needed.

Closes #155 