### PR TITLE
remove use of reserved nil values from race buffer

### DIFF
--- a/race-buffer/model/Makefile
+++ b/race-buffer/model/Makefile
@@ -24,7 +24,7 @@ tla2tools.jar:
 	(grep -q "\-\-algorithm" $*.tla && ${PLUSCAL} $*.tla) || true
 
 	@ echo "\n\n-------------- TLC ------------------"
-	${TLC} -workers ${WORKERS} -metadir metadir/check/$* $*.tla 2>&1 | tee $@.tmp
+	${TLC} -deadlock -workers ${WORKERS} -metadir metadir/check/$* $*.tla 2>&1 | tee $@.tmp
 	@ echo "-------------------------------------\n\n"
 	@! grep "Error:" $@.tmp
 	mv $@.tmp $@

--- a/race-buffer/model/RaceBuffer.cfg
+++ b/race-buffer/model/RaceBuffer.cfg
@@ -4,7 +4,7 @@
 
 CONSTANTS
     BufCapacity = 4
-    NumWrites = 8
+    NumWrites = 10
 
 INIT Init
 NEXT Next
@@ -12,5 +12,10 @@ NEXT Next
 \* PROPERTY
 \* Uncomment the previous line and add property names
 
-INVARIANT InvCorrectIndeces InvConsistentDoubles
+INVARIANT 
+    InvRcursBehindWcurs
+    InvWcursBehindOwcurs
+    InvReadBufferNotTooBig
+    InvCorrectIndeces 
+    InvConsistentDoubles
 \* Uncomment the previous line and add invariant names

--- a/race-buffer/model/RaceBuffer.tla
+++ b/race-buffer/model/RaceBuffer.tla
@@ -6,7 +6,7 @@ CONSTANTS
 
   NumWrites  (* Number of writes to execute *)
 
-ASSUME Assumption == BufCapacity \in Nat\*(Nat \ 0..2) (* Buffer capacity is at least 3 *)
+ASSUME Assumption == BufCapacity \in (Nat \ 0..2) (* Buffer capacity is at least 3 *)
 
 -----------------------------------------------------------------------------
 
@@ -294,7 +294,7 @@ InvStoredPrefixNotSuffix ==
   storedPrefix.type = "NONE" \/ storedPrefix.type = "PREFIX"
 
 (* Check that every non-nil entry is at the correct index in the read buffer *)
-InvCorrectIndeces == 
+InvCorrectIndices == 
   IF Size(rbuf) > 0 
   THEN \A i \in 0..(Size(rbuf)-1): rbuf[i].index = i \/ rbuf[i].type = "MISSED"
   ELSE TRUE

--- a/race-buffer/model/RaceBuffer.tla
+++ b/race-buffer/model/RaceBuffer.tla
@@ -6,111 +6,93 @@ CONSTANTS
 
   NumWrites  (* Number of writes to execute *)
 
-ASSUME Assumption == BufCapacity \in (Nat \ 0..2) (* Buffer capacity is at least 3 *)
+ASSUME Assumption == BufCapacity \in Nat\*(Nat \ 0..2) (* Buffer capacity is at least 3 *)
 
 -----------------------------------------------------------------------------
 
 VARIABLES 
   wpc, (* Writer's program counter *)
   buf, (* Backing storage *)
-  wcurs, (* Write cursor - Equal to number of entries already written *)
-
-  writes, (* Number of entries written (used to limit state space) *)
+  wcurs, (* Write cursor - Points to next write position *)
+  owcurs, (* Overwrite cursor - Marks where space is allocated for the writer to write freely *)
 
   rpc, (* Reader's program counter *)
   rbuf, (* Buffer of entries already read *)
   bufSnap, (* Intermediate buffer used to store a snapshot of entries being read *)
-  rcurs, (* Read cursor - Equal to number of entries already read*)
-  wcursSnap (* Value of wcurs observed at beginning of read *)
+  rcurs, (* Read cursor - Points to next read position *)
+  wcursSnap, (* Value of write cursor observed at beginning of read *)
+  storedPrefix, (* Prefix to be written to read buffer once suffix is read *)
+  processingIndex (* Index of next entry in bufSnap to process *)
 
 -----------------------------------------------------------------------------
 
 (* Writer helpers *)
 
 (* Construct an entry structure - Index field is only used to check *)
-(* ordering in the read buffer of non-nil entries. *)
+(* ordering in the reader's output buffer *)
 Entry(i, t) == [index |-> i, type |-> t]
 
-(* Get index in backing storage based on entry index *)
+(* Get index in backing storage based on given cursor *)
 BufIndex(i) == i % BufCapacity
 
-(* Get entry in storage position of given index *)
+(* Get entry in storage position of given cursor *)
 Read(i) == buf[BufIndex(i)]
 
 (* Write a single entry of given type at given index *)
 Write(i, t) == buf' = (BufIndex(i) :> Entry(i,t)) @@ buf
 
-(* Write the appropriately typed non-nil entry at the given index *)
+(* Either write a single entry or the prefix of a double entry *)
+WriteNewEntry(i) == 
+  \/ Write(i, "SINGLE")
+  \/ Write(i, "PREFIX")
+
+(* Write the appropriately typed entry at the given index *)
 WriteEntry(i) == 
-  /\ IF Read(i - 1).type = "PREFIX"
-     THEN Write(i, "SUFFIX")
-     ELSE \/ Write(i, "SINGLE")
-          \/ Write(i, "PREFIX")
-  /\ writes' = writes + 1
+  IF i = 0 
+  THEN WriteNewEntry(i) 
+  ELSE IF Read(i - 1).type = "PREFIX"
+       THEN Write(i, "SUFFIX")
+       ELSE WriteNewEntry(i)
+
+(* Overwrite old entry by incrementing overwrite cursor *)
+OverwriteOldEntry == 
+    IF owcurs < BufCapacity 
+    THEN owcurs' = owcurs + 1
+    ELSE IF Read(owcurs).type = "PREFIX" 
+         THEN owcurs' = owcurs + 2
+         ELSE owcurs' = owcurs + 1
 
 -----------------------------------------------------------------------------
 
 (* Writer steps *)
 
+(* If the write cursor has reached the overwrite cursor, then another entry 
+   must be overwritten to allocate space for more writes *)
+Overwrite == 
+    /\ wpc = "overwrite"
+    /\ IF wcurs = owcurs 
+       THEN OverwriteOldEntry
+       ELSE UNCHANGED owcurs
+    /\ wpc' = "write"
+    /\ UNCHANGED wcurs
+    /\ UNCHANGED buf
 
 (* Writer either writes nil entry at wcurs or transitions to OverwriteSuf in
    the case that a double entry is being overwritten *)
-Overwrite == 
-  /\ wpc = "overwrite"
-  /\ IF Read(wcurs).type = "PREFIX" 
-     THEN /\ wpc' = "overwriteSuf"
-          /\ UNCHANGED buf
-     ELSE /\ Write(wcurs, "NIL")
-          /\ wpc' = "incrementWCursor"
+WriteStep == 
+  /\ wpc = "write"
+  /\ WriteEntry(wcurs)
+  /\ wpc' = "incrWriteCursor"
   /\ UNCHANGED wcurs
-  /\ UNCHANGED writes
-
-(* Writer must overwrite a double entry. First, the suffix is replaced with 
-   a nil entry. *)
-OverwriteSuf == 
-  /\ wpc = "overwriteSuf"
-  /\ Write(wcurs + 1, "NIL")
-  /\ wpc' = "overwritePre"
-  /\ UNCHANGED wcurs
-  /\ UNCHANGED writes
-
-(* Overwrite the prefix of a double entry with a nil value *)
-OverwritePre == 
-  /\ wpc = "overwritePre"
-  /\ Write(wcurs, "NIL")
-  /\ wpc' = "doubleIncrementWCursor"
-  /\ UNCHANGED wcurs
-  /\ UNCHANGED writes
+  /\ UNCHANGED owcurs
 
 (* Increment the write cursor by 1 *)
-IncrementWCursor ==
-  /\ wpc = "incrementWCursor"
+IncrWriteCursor ==
+  /\ wpc = "incrWriteCursor"
   /\ wcurs' = wcurs + 1
-  /\ wpc'= "writeSuf"
+  /\ wpc'= "overwrite"
+  /\ UNCHANGED owcurs
   /\ UNCHANGED buf
-  /\ UNCHANGED writes
-
-(* Increment the write cursor by 2 *)
-DoubleIncrementWCursor ==
-  /\ wpc = "doubleIncrementWCursor"
-  /\ wcurs' = wcurs + 2
-  /\ wpc'= "writePre"
-  /\ UNCHANGED buf
-  /\ UNCHANGED writes
-
-(* Write the prefix of double entry *)
-WritePre ==
-  /\ wpc = "writePre"
-  /\ WriteEntry(wcurs - 2)
-  /\ wpc' = "writeSuf"
-  /\ UNCHANGED wcurs
-
-(* Write a single entry, or the suffix of double entry *)
-WriteSuf == 
-  /\ wpc = "writeSuf"
-  /\ WriteEntry(wcurs - 1)
-  /\ wpc' = "overwrite"
-  /\ UNCHANGED wcurs
 
 -----------------------------------------------------------------------------
 
@@ -119,24 +101,21 @@ WriteSuf ==
 WriterInit == 
   /\ wpc = "overwrite"
   /\ wcurs = 0
-  /\ buf = [i \in 0..BufCapacity-1 |-> Entry(0, "NIL")]
+  /\ owcurs = 0
+  /\ buf = <<>>
 
 (* Wait when reader takes steps *)
 WriterWait ==
   /\ UNCHANGED wpc
   /\ UNCHANGED wcurs
   /\ UNCHANGED buf
-  /\ UNCHANGED writes
+  /\ UNCHANGED owcurs
 
 (* Take appropriate step based on wpc *)
 WriterStep ==
   \/ Overwrite
-  \/ OverwriteSuf
-  \/ OverwritePre
-  \/ IncrementWCursor
-  \/ DoubleIncrementWCursor
-  \/ WritePre
-  \/ WriteSuf
+  \/ WriteStep
+  \/ IncrWriteCursor
 
 -----------------------------------------------------------------------------
 
@@ -145,62 +124,25 @@ WriterStep ==
 (* Return number of keys in a function *)
 Size(f) == Cardinality(DOMAIN f)
 
-(* Return (maximum index + 1) of integer keyed function, or 0 if no keys *)
-NextIndex(f) == IF Size(f) = 0 THEN 0 ELSE (CHOOSE i \in DOMAIN f: \A j \in DOMAIN f: i >= j)+1
+(* Calculate the cursor value of the first item read during this read *)
+FirstRead(rc, snapLen) == rc - snapLen
 
-(* Return minimum of integer keyed function, or 0 if no keys *)
-MinIndex(f) == IF Size(f) = 0 THEN 0 ELSE CHOOSE i \in DOMAIN f: \A j \in DOMAIN f: i <= j
+(* Return number of entries past rc overwritten based on given owc *)
+Overlap(owc, rc) == IF owc < (rc + BufCapacity) THEN 0 ELSE owc - (rc + BufCapacity)
 
-(* Return number of entries past rc overwritten based on given wc *)
-Overlap(wc, rc) == IF wc < (rc + BufCapacity) THEN 0 ELSE wc - (rc + BufCapacity)
+(* Return number of entries past first read overwritten (Maximum is snap buffer size) *)
+OverlapRead(owc, rc, snapLen) == IF Overlap(owc, FirstRead(rc, snapLen)) <= snapLen 
+                                 THEN Overlap(owc, FirstRead(rc, snapLen)) 
+                                 ELSE snapLen
 
-(* If the last entry of read buffer is a prefix entry, replace it with a nil entry. *)
-(* This is used whenever a nil entry is appended to the read buffer to prevent *)
-(* prefixes with missing suffixes from occurring. *)
-ReplacePrefixNil(rb) == 
-  IF Size(rb) > 0
-  THEN IF rb[NextIndex(rb)-1].type = "PREFIX"
-       THEN [rb EXCEPT ![NextIndex(rb)-1] = Entry(0, "NIL")]
-       ELSE rb
-  ELSE rb
-
-(* Remove the entries from the snapshot that may have been overwritten based on the write cursor *)
-RemoveOverlap(snap) == 
-  [i \in (MinIndex(snap)+Overlap(wcurs, rcurs-Size(bufSnap)))..(NextIndex(snap)-1)
-   |-> snap[i]]
-
-(* Append given entry to read buffer, replacing last prefix with nil if suffix is lost *)
+(* Append given entry to reader's buffer *)
 AppendEntry(rb, entry) == 
-  (IF entry.type = "NIL" THEN ReplacePrefixNil(rb) ELSE rb) @@ (Size(rb) :> entry)
+  rb @@ (Size(rb) :> entry)
 
-(* Append n nils to read buffer *)
-RECURSIVE AppendNils(_,_)
-AppendNils(rb, n) == 
-  IF n = 0 THEN rb ELSE AppendNils(AppendEntry(rb, Entry(0, "NIL")), n-1)
-
-(* Append snapshot to read buffer *)
-RECURSIVE AppendSnap(_,_,_,_)
-AppendSnap(rb, snap, start, end) == 
-  IF start >= end THEN rb 
-  ELSE AppendSnap(AppendEntry(rb, snap[start]), snap, start+1, end)
-
-(* Return 1 if last entry of snap is nil, else 0 *)
-CheckNilEnd(snap) == 
-  IF snap[NextIndex(snap)-1].type = "NIL"
-  THEN 1
-  ELSE 0
-
-(* Return number of nils at end of snap for snaps of length 2 or more *)
-CheckDoubleNilEnd(snap) ==
-  IF snap[NextIndex(snap)-2].type = "NIL" 
-  THEN 2
-  ELSE CheckNilEnd(snap)
-
-(* Return number of nils at end of snap *)
-NumNilsEnd(snap) == 
-  CASE Size(snap) >= 2 -> CheckDoubleNilEnd(snap)
-    [] Size(snap) = 1 -> CheckNilEnd(snap)
-    [] Size(snap) = 0 -> 0
+(* Append n missed entries to read buffer *)
+RECURSIVE AppendMissed(_,_)
+AppendMissed(rb, n) == 
+  IF n = 0 THEN rb ELSE AppendMissed(AppendEntry(rb, Entry(0, "MISSED")), n-1)
 
 -----------------------------------------------------------------------------
 
@@ -208,45 +150,84 @@ NumNilsEnd(snap) ==
   
 (* At the start of a read, reader takes a snapshot of the write cursor and appends
    nil entries to the read buffer if any entries were missed between reads *)
-SnapWCurs == 
-  /\ rpc = "snapWCurs"
+SnapWriteCursor == 
+  /\ rpc = "snapWriteCursor"
   /\ wcursSnap' = wcurs
-  /\ rbuf' = AppendNils(rbuf, Overlap(wcurs, rcurs))
-  /\ rcurs' = rcurs + Overlap(wcurs, rcurs)
+  /\ UNCHANGED rbuf
+  /\ UNCHANGED rcurs
+  /\ rpc' = "snapOverwriteCursor"
+  /\ bufSnap' = <<>>
+  /\ UNCHANGED storedPrefix
+  /\ UNCHANGED processingIndex
+
+(* Observe the current value of the overwrite cursor, and based on that value,
+   append any missed entries to reader's buffer and update reader's cursor *)
+SnapOverwriteCursor ==
+  /\ rpc = "snapOverwriteCursor"
+  /\ UNCHANGED wcursSnap
+  /\ IF Overlap(owcurs, rcurs) > 0 /\ ~(storedPrefix.type = "NONE")
+     THEN /\ rbuf' = AppendMissed(rbuf, Overlap(owcurs, rcurs) + 1)
+          /\ storedPrefix' = Entry(0, "NONE")
+     ELSE /\ rbuf' = AppendMissed(rbuf, Overlap(owcurs, rcurs))
+          /\ UNCHANGED storedPrefix
+  /\ rcurs' = rcurs + Overlap(owcurs, rcurs)
   /\ rpc' = "snapEntry"
   /\ bufSnap' = <<>>
+  /\ UNCHANGED processingIndex
 
 (* Take a snapshot of a single entry, then move on to next entry until read cursor reaches
-   snapshot of write cursor *)
+   write cursor *)
 SnapEntry == 
   /\ rpc = "snapEntry"
-  /\ IF rcurs = wcursSnap
-     THEN /\ rpc' = "processSnap"
+  /\ IF rcurs >= wcursSnap
+     THEN /\ rpc' = "processOverwritten"
           /\ UNCHANGED bufSnap
           /\ UNCHANGED rcurs
-     ELSE /\ bufSnap' = (rcurs :> Read(rcurs)) @@ bufSnap
+     ELSE /\ UNCHANGED rpc
+          /\ bufSnap' = (Size(bufSnap) :> Read(rcurs)) @@ bufSnap
           /\ rcurs' = rcurs + 1
-          /\ UNCHANGED rpc
   /\ UNCHANGED wcursSnap
   /\ UNCHANGED rbuf
+  /\ UNCHANGED processingIndex
+  /\ UNCHANGED storedPrefix
 
-(* Process entries in snapshot buffer, appending entries that have not been overwritten
-   to read buffer. If the write cursor has lapped the read cursor, than all entries in the 
-   snapshot buffer have been overwritten. *)
-ProcessSnap == 
-  /\ rpc = "processSnap"
-  /\ rpc' = "snapWCurs"
-  /\ IF wcurs >= rcurs + BufCapacity
-     THEN /\ rbuf' = AppendNils(rbuf, Size(bufSnap))
-          /\ UNCHANGED rcurs
-     ELSE /\ rbuf' = AppendSnap(
-               AppendNils(rbuf, Overlap(wcurs, rcurs-Size(bufSnap))),
-               RemoveOverlap(bufSnap), 
-               MinIndex(RemoveOverlap(bufSnap)),
-               NextIndex(bufSnap) - NumNilsEnd(RemoveOverlap(bufSnap))
-             )
-          /\ rcurs' = rcurs - NumNilsEnd(RemoveOverlap(bufSnap))
+(* Calculate how entries from previous read might have been overwritten based
+   on current value of overwrite cursor. Append that many missed values to the
+   reader's buffer, potentially replacing a stored prefix with a missed value *)
+ProcessOverwritten == 
+  /\ rpc = "processOverwritten"
+  /\ rpc' = "processEntry"
+  /\ processingIndex' = OverlapRead(owcurs, rcurs, Size(bufSnap))
+  /\ IF ~(storedPrefix.type = "NONE") /\ OverlapRead(owcurs, rcurs, Size(bufSnap)) > 0
+     THEN /\ rbuf' = AppendMissed(rbuf, OverlapRead(owcurs, rcurs, Size(bufSnap)) + 1)
+          /\ storedPrefix = Entry(0, "NONE")
+     ELSE /\ rbuf' = AppendMissed(rbuf, OverlapRead(owcurs, rcurs, Size(bufSnap)))
+          /\ UNCHANGED storedPrefix
   /\ UNCHANGED bufSnap
+  /\ UNCHANGED rcurs
+  /\ UNCHANGED wcursSnap
+  
+(* Process a single entry in the buffer snapshot by either storing it in the reader's 
+   buffer or as a stored prefix *)
+ProcessEntry == 
+  /\ rpc = "processEntry"
+  /\ IF processingIndex = Size(bufSnap)
+     THEN /\ rpc' = "snapWriteCursor"
+          /\ UNCHANGED processingIndex
+          /\ UNCHANGED rbuf
+          /\ UNCHANGED storedPrefix
+     ELSE /\ UNCHANGED rpc
+          /\ processingIndex' = processingIndex + 1
+          /\ IF storedPrefix.type = "NONE"
+             THEN IF ~(bufSnap[processingIndex].type = "SINGLE")
+                  THEN /\ storedPrefix' = bufSnap[processingIndex]
+                       /\ UNCHANGED rbuf
+                  ELSE /\ rbuf' = AppendEntry(rbuf, bufSnap[processingIndex])
+                       /\ UNCHANGED storedPrefix
+             ELSE /\ rbuf' = AppendEntry(AppendEntry(rbuf, storedPrefix), bufSnap[processingIndex])
+                  /\ storedPrefix' = Entry(0, "NONE")
+  /\ UNCHANGED bufSnap
+  /\ UNCHANGED rcurs
   /\ UNCHANGED wcursSnap
 
 -----------------------------------------------------------------------------
@@ -254,11 +235,13 @@ ProcessSnap ==
 (* Reader *)
 
 ReaderInit ==
-  /\ rpc = "snapWCurs"
+  /\ rpc = "snapWriteCursor"
   /\ rbuf = <<>>
   /\ bufSnap = <<>>
   /\ rcurs = 0
   /\ wcursSnap = 0
+  /\ storedPrefix = Entry(0, "NONE")
+  /\ processingIndex = 0
 
 (* Wait when writer takes a step *)
 ReaderWait ==
@@ -267,42 +250,62 @@ ReaderWait ==
   /\ UNCHANGED bufSnap
   /\ UNCHANGED rcurs
   /\ UNCHANGED wcursSnap
+  /\ UNCHANGED storedPrefix
+  /\ UNCHANGED processingIndex
 
 (* Take appropriate step based on rpc *)
 ReaderStep == 
-  \/ SnapWCurs
+  \/ SnapWriteCursor
+  \/ SnapOverwriteCursor
   \/ SnapEntry
-  \/ ProcessSnap  
+  \/ ProcessOverwritten
+  \/ ProcessEntry  
 
 -----------------------------------------------------------------------------
 
 Init == 
   /\ ReaderInit
   /\ WriterInit
-  /\ writes = 0
 
-(* Either take reader step or writer step. Stop writer after writes reaches numWrites *)
+(* Either take reader step or writer step. Stop writer after wcurs reaches numWrites *)
 Next ==
   \/ WriterWait /\ ReaderStep 
-  \/ ReaderWait /\ WriterStep /\ writes < NumWrites
+  \/ ReaderWait /\ WriterStep /\ wcurs < NumWrites
 
 -----------------------------------------------------------------------------
 
 (* Invariants *)
 
+(* Read cursor cannot overtake write cursor *)
+InvRcursBehindWcurs ==
+  rcurs <= wcurs
+
+(* Write cursor cannot overtake overwrite cursor *)
+InvWcursBehindOwcurs ==
+  wcurs <= owcurs
+
+(* Reader's buffer cannot contain more elements than reader's cursor value *)
+InvReadBufferNotTooBig ==
+  Size(rbuf) <= rcurs
+
+(* Since suffixes could possibly be interpreted as prefixes, ensure that suffixes
+   are stored as a prefix *)
+InvStoredPrefixNotSuffix == 
+  storedPrefix.type = "NONE" \/ storedPrefix.type = "PREFIX"
+
 (* Check that every non-nil entry is at the correct index in the read buffer *)
 InvCorrectIndeces == 
   IF Size(rbuf) > 0 
-  THEN \A i \in 0..(NextIndex(rbuf)-1): rbuf[i].index = i \/ rbuf[i].type = "NIL"
+  THEN \A i \in 0..(Size(rbuf)-1): rbuf[i].index = i \/ rbuf[i].type = "MISSED"
   ELSE TRUE
 
 (* Check that every prefix has a suffix and vice versa*)
 InvConsistentDoubles == 
   CASE Size(rbuf) = 0 -> TRUE
-  [] Size(rbuf) = 1 -> ~(rbuf[0].type = "SUFFIX")
+  [] Size(rbuf) = 1 -> ~(rbuf[0].type = "SUFFIX" \/ rbuf[Size(rbuf)-1].type = "PREFIX")
   [] Size(rbuf) >= 2 -> 
-    /\ ~(rbuf[0].type = "SUFFIX")
-    /\ \A i \in 0..(NextIndex(rbuf)-2): 
+    /\ ~(rbuf[0].type = "SUFFIX" \/ rbuf[Size(rbuf)-1].type = "PREFIX")
+    /\ \A i \in 0..(Size(rbuf)-2): 
           rbuf[i].type = "PREFIX" <=> rbuf[i+1].type = "SUFFIX"
 
 =============================================================================

--- a/race-buffer/src/lib.rs
+++ b/race-buffer/src/lib.rs
@@ -3,13 +3,14 @@
 use core::cmp::PartialEq;
 use core::marker::Copy;
 
+/// Entry that can be stored in RaceBuffer
 pub trait Entry: Copy + PartialEq {
-    //const NIL_VAL: Self;
+    /// Return true if entry is the first in a double entry
     fn is_prefix(&self) -> bool;
 }
 
-#[inline]
 /// Returns the corresponding index in backing storage of given cursor index
+#[inline]
 fn get_cursor_index(storage_cap: usize, cursor: usize, use_base_2_indexing: bool) -> usize {
     if use_base_2_indexing {
         // Index is lowest n bits of cursor where storage_cap is 2^n
@@ -42,8 +43,6 @@ pub mod tests {
     pub struct OrderedEntry(u32);
 
     impl Entry for OrderedEntry {
-        //const NIL_VAL: OrderedEntry = OrderedEntry(0);
-
         fn is_prefix(&self) -> bool {
             assert!(!self.is_suffix());
             self.is_prefix_unchecked()
@@ -57,7 +56,7 @@ pub mod tests {
         pub(crate) fn to_index(&self) -> u32 {
             if self.is_suffix() {
                 self.0 - Self::SUFFIX_TAG
-            } else if self.is_prefix() {
+            } else if self.is_prefix_unchecked() {
                 self.0 - Self::PREFIX_TAG
             } else {
                 self.0
@@ -80,7 +79,7 @@ pub mod tests {
         }
 
         pub(crate) fn is_prefix_unchecked(&self) -> bool {
-            self.0 > Self::PREFIX_TAG
+            self.0 >= Self::PREFIX_TAG
         }
 
         pub(crate) fn is_suffix(&self) -> bool {
@@ -89,11 +88,9 @@ pub mod tests {
 
         // Invariant: Check if entries all have correct index
         fn entries_correct_index(rbuf: &[Option<OrderedEntry>]) -> bool {
-            for i in 0..rbuf.len() {
-                if let Some(entry) = rbuf[i] {
-                    if entry.to_index() != i as u32 + 1 {
-                        return false;
-                    }
+            for (idx, entry) in rbuf.iter().enumerate().filter(|(_, e)| e.is_some()) {
+                if entry.unwrap().to_index() != idx as u32 {
+                    return false;
                 }
             }
             return true;
@@ -101,12 +98,15 @@ pub mod tests {
 
         // Invariant: Check if entries all have correct index
         fn double_entries_consistent(rbuf: &[Option<OrderedEntry>]) -> bool {
+            if rbuf.len() == 0 {
+                return true;
+            }
             if let Some(first_entry) = rbuf[0] {
                 if first_entry.is_suffix() {
                     return false;
                 }
             }
-            if let Some(last_entry) = rbuf[rbuf.len() - 1] {
+            if let Some(last_entry) = rbuf.last().unwrap() {
                 if last_entry.is_prefix_unchecked() {
                     return false;
                 }
@@ -167,12 +167,12 @@ pub mod tests {
             s.spawn(move |_| {
                 let mut storage = [MaybeUninit::uninit(); STORAGE_CAP];
 
-                let mut buf = writer::RaceBuffer::new(&mut storage[..], false);
+                let mut buf = writer::RaceBuffer::new(&mut storage[..], false).unwrap();
                 assert!(buf.get_slice().len() == STORAGE_CAP);
                 let buf_ptr = &buf as *const writer::RaceBuffer<'_, OrderedEntry> as usize;
                 ptr_s.send(buf_ptr).unwrap();
 
-                for i in 1..=NUM_WRITES {
+                for i in 0..NUM_WRITES {
                     buf.write(OrderedEntry::from_index(i));
                     std::thread::sleep(Duration::from_millis(10));
                 }
@@ -213,15 +213,13 @@ pub mod tests {
         crossbeam::thread::scope(|s| {
             s.spawn(move |_| {
                 let mut storage = [MaybeUninit::uninit(); RAW_STORAGE_CAP];
-
-                let mut buf = writer::RaceBuffer::new(&mut storage[..], true);
+                let mut buf = writer::RaceBuffer::new(&mut storage[..], true).unwrap();
                 assert!(buf.get_slice().len() == STORAGE_CAP);
                 let buf_ptr = &buf as *const writer::RaceBuffer<'_, OrderedEntry> as usize;
                 ptr_s.send(buf_ptr).unwrap();
-
                 let mut rng = rand::thread_rng();
                 let mut last_prefix = false;
-                for i in 1..=NUM_WRITES {
+                for i in 0..NUM_WRITES {
                     if last_prefix {
                         buf.write(OrderedEntry::from_index_suffix(i));
                         last_prefix = false;
@@ -265,5 +263,41 @@ pub mod tests {
             });
         })
         .unwrap();
+    }
+
+    /// Test backing storage size rounding and minimum size enforcement
+    #[test]
+    fn test_init_sizes() {
+        // Ensure minimum storage size is checked
+        let mut too_small_storage =
+            [MaybeUninit::<OrderedEntry>::uninit(); writer::MIN_STORAGE_CAP - 1];
+        assert!(writer::RaceBuffer::new(&mut too_small_storage[..], false).is_err());
+        assert!(writer::RaceBuffer::new(&mut too_small_storage[..], true).is_err());
+
+        let input_sizes = [5, 6, 7, 8, 9, 12, 16];
+
+        let output_sizes: Vec<usize> = input_sizes
+            .iter()
+            .map(|size| {
+                let mut storage = vec![MaybeUninit::<OrderedEntry>::uninit(); *size];
+                writer::RaceBuffer::new(&mut storage[..], false)
+                    .unwrap()
+                    .get_slice()
+                    .len()
+            })
+            .collect();
+        assert_eq!(&input_sizes[..], &output_sizes[..]);
+
+        let rounded_output_sizes: Vec<usize> = input_sizes
+            .iter()
+            .map(|size| {
+                let mut storage = vec![MaybeUninit::<OrderedEntry>::uninit(); *size];
+                writer::RaceBuffer::new(&mut storage[..], true)
+                    .unwrap()
+                    .get_slice()
+                    .len()
+            })
+            .collect();
+        assert_eq!(&[4, 4, 4, 8, 8, 8, 16][..], &rounded_output_sizes[..]);
     }
 }

--- a/race-buffer/src/lib.rs
+++ b/race-buffer/src/lib.rs
@@ -2,227 +2,37 @@
 
 use core::cmp::PartialEq;
 use core::marker::Copy;
-#[cfg(feature = "std")]
-use core::marker::PhantomData;
-
-#[cfg(not(feature = "std"))]
-use core::fmt;
-#[cfg(feature = "std")]
-use std::fmt;
 
 pub trait Entry: Copy + PartialEq {
-    const NIL_VAL: Self;
+    //const NIL_VAL: Self;
     fn is_prefix(&self) -> bool;
-}
-
-pub trait Snapper<E>
-where
-    E: Entry,
-{
-    fn snap_wcurs(&self) -> usize;
-    fn snap_storage(&self, index: usize) -> E;
-}
-
-pub struct SizeError();
-
-impl fmt::Debug for SizeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("Storage size must be a power of 2")
-    }
 }
 
 #[inline]
 /// Returns the corresponding index in backing storage of given cursor index
-fn get_cursor_index(storage_cap: usize, cursor: usize) -> usize {
-    // Index is lowest n bits of cursor where storage_cap is 2^n
-    cursor & (storage_cap - 1)
-}
-#[repr(C)]
-/// Struct used to write to buffer
-pub struct RaceBuffer<'a, E>
-where
-    E: Entry,
-{
-    /// Writer's cursor
-    wcurs: usize,
-    /// Backing storage
-    storage: &'a mut [E],
-}
-
-impl<'a, E> RaceBuffer<'a, E>
-where
-    E: Entry,
-{
-    /// Create new RaceBuffer. Returns error if storage size is not power of 2
-    pub fn new(storage: &'a mut [E]) -> Result<RaceBuffer<'a, E>, SizeError> {
-        let exp = storage.len().trailing_zeros();
-        if storage.len() != 1usize << exp {
-            return Err(SizeError());
-        }
-
-        Ok(RaceBuffer { wcurs: 0, storage })
-    }
-
-    /// Write single entry to buffer
-    pub fn write(&mut self, data: E) {
-        let write_offset = get_cursor_index(self.storage.len(), self.wcurs);
-        if self.wcurs > 0 {
-            let before_offset = get_cursor_index(self.storage.len(), self.wcurs - 1);
-            if self.storage[before_offset] == E::NIL_VAL {
-                // Previous write left free nil value behind wcurs
-                self.storage[before_offset] = data;
-                return;
-            }
-        }
-
-        if self.storage[write_offset] != E::NIL_VAL && self.storage[write_offset].is_prefix() {
-            // Overwriting double entry, must first overwrite suffix
-            let suffix_offset = get_cursor_index(self.storage.len(), self.wcurs + 1);
-            self.storage[suffix_offset] = E::NIL_VAL;
-            self.storage[write_offset] = E::NIL_VAL;
-            self.wcurs += 2;
-        } else {
-            self.storage[write_offset] = E::NIL_VAL;
-            self.wcurs += 1;
-        }
-        self.storage[write_offset] = data;
-    }
-
-    /// Get value of backing storage corresponding to given cursor
-    pub fn read_storage(&self, curs: usize) -> E {
-        self.storage[get_cursor_index(self.storage.len(), curs)]
-    }
-
-    /// Get current value of write cursor
-    pub fn read_wcurs(&self) -> usize {
-        self.wcurs
+fn get_cursor_index(storage_cap: usize, cursor: usize, use_base_2_indexing: bool) -> usize {
+    if use_base_2_indexing {
+        // Index is lowest n bits of cursor where storage_cap is 2^n
+        cursor & (storage_cap - 1)
+    } else {
+        cursor % storage_cap
     }
 }
+
+pub mod writer;
 
 #[cfg(feature = "std")]
-/// Struct used to read from a RaceBuffer asynchronously
-pub struct RaceBufferReader<E, S>
-where
-    E: Entry,
-    S: Snapper<E>,
-{
-    /// Struct for reading writer state
-    snapper: S,
-    /// Reader's cursor
-    rcurs: usize,
-    /// Capacity of backing storage
-    storage_cap: usize,
-    phantom: PhantomData<E>,
-}
-
-#[cfg(feature = "std")]
-impl<E, S> RaceBufferReader<E, S>
-where
-    E: Copy + PartialEq + Entry,
-    S: Snapper<E>,
-{
-    /// Create new RaceBufferReader
-    pub fn new(snapper: S, storage_cap: usize) -> RaceBufferReader<E, S> {
-        RaceBufferReader {
-            snapper,
-            rcurs: 0,
-            storage_cap,
-            phantom: PhantomData,
-        }
-    }
-
-    /// Attempt to read all new entries in race buffer into given read buffer
-    pub fn read(&mut self, rbuf: &mut Vec<E>) {
-        let pre_wcurs = self.snapper.snap_wcurs();
-        if pre_wcurs > self.storage_cap + self.rcurs {
-            // If writer has overwritten unread entries, store nils and correct rcurs
-            let num_missed = pre_wcurs - (self.rcurs + self.storage_cap);
-            self.store_nil(num_missed, rbuf);
-            self.rcurs = pre_wcurs - self.storage_cap;
-        }
-
-        // Perform reads into snapshot buffer
-        let first_read = self.rcurs;
-        let mut buf_snapshot: Vec<E> = Vec::new();
-        while self.rcurs < pre_wcurs {
-            let storage_index = get_cursor_index(self.storage_cap, self.rcurs);
-            buf_snapshot.push(self.snapper.snap_storage(storage_index));
-            self.rcurs += 1;
-        }
-
-        // Calculate number of entries in snapshot buffer that may have been overwritten
-        let post_wcurs = self.snapper.snap_wcurs();
-        let overlap = if post_wcurs > self.storage_cap + first_read {
-            (post_wcurs - self.storage_cap) - first_read
-        } else {
-            0
-        };
-        if overlap >= buf_snapshot.len() {
-            // All entries may have been overwritten, return
-            self.store_nil(buf_snapshot.len(), rbuf);
-            return;
-        }
-        self.store_nil(overlap, rbuf);
-        let mut valid_snapshot = &mut buf_snapshot[overlap..];
-
-        let last_index = valid_snapshot.len() - 1;
-        if valid_snapshot.len() >= 2 && valid_snapshot[last_index - 1] == E::NIL_VAL {
-            // Writer was possibly not finished writing last two entries, roll
-            // back read by 2
-            valid_snapshot = &mut valid_snapshot[..last_index - 1];
-            self.rcurs -= 2;
-        } else if valid_snapshot[last_index] == E::NIL_VAL {
-            // Writer was possibly not finished writing last entry,
-            // roll back read by 1
-            valid_snapshot = &mut valid_snapshot[..last_index];
-            self.rcurs -= 1;
-        }
-
-        // Store valid entries in read buffer
-        for entry in valid_snapshot {
-            self.store(*entry, rbuf);
-        }
-    }
-
-    /// Store given entry in given read buffer,
-    /// replacing stored prefixes with nil if suffix is nil
-    fn store(&mut self, entry: E, rbuf: &mut Vec<E>) {
-        if entry == E::NIL_VAL {
-            let last_entry_opt = rbuf.pop();
-            match last_entry_opt {
-                None => rbuf.push(E::NIL_VAL),
-                Some(last_entry) => {
-                    if last_entry.is_prefix() {
-                        // Suffix lost, replace prefix with nil
-                        rbuf.push(E::NIL_VAL);
-                        rbuf.push(E::NIL_VAL);
-                    } else {
-                        rbuf.push(last_entry);
-                        rbuf.push(E::NIL_VAL);
-                    }
-                }
-            }
-        } else {
-            rbuf.push(entry);
-        }
-    }
-
-    #[inline]
-    /// Store given number of nil entries in given read buffer
-    fn store_nil(&mut self, num: usize, rbuf: &mut Vec<E>) {
-        for _ in 0..num {
-            self.store(E::NIL_VAL, rbuf);
-        }
-    }
-}
+pub mod reader;
 
 #[cfg(feature = "std")]
 #[cfg(test)]
 pub mod tests {
     use super::*;
 
+    use core::mem::MaybeUninit;
     use crossbeam;
     use rand::Rng;
+    use std::error::Error;
     use std::sync::{Arc, Barrier};
     use std::thread;
     use std::time::Duration;
@@ -232,10 +42,11 @@ pub mod tests {
     pub struct OrderedEntry(u32);
 
     impl Entry for OrderedEntry {
-        const NIL_VAL: OrderedEntry = OrderedEntry(0);
+        //const NIL_VAL: OrderedEntry = OrderedEntry(0);
 
         fn is_prefix(&self) -> bool {
-            self.0 > Self::PREFIX_TAG
+            assert!(!self.is_suffix());
+            self.is_prefix_unchecked()
         }
     }
 
@@ -243,7 +54,7 @@ pub mod tests {
         const PREFIX_TAG: u32 = 0x80000000; // 2^31
         const SUFFIX_TAG: u32 = 0x40000000; // 2^30
 
-        pub(crate) fn to_raw(&self) -> u32 {
+        pub(crate) fn to_index(&self) -> u32 {
             if self.is_suffix() {
                 self.0 - Self::SUFFIX_TAG
             } else if self.is_prefix() {
@@ -268,62 +79,97 @@ pub mod tests {
             OrderedEntry(i + Self::SUFFIX_TAG)
         }
 
+        pub(crate) fn is_prefix_unchecked(&self) -> bool {
+            self.0 > Self::PREFIX_TAG
+        }
+
         pub(crate) fn is_suffix(&self) -> bool {
             self.0 >= Self::SUFFIX_TAG && self.0 < Self::PREFIX_TAG
         }
 
         // Invariant: Check if entries all have correct index
-        fn entries_correct_index(rbuf: &[OrderedEntry]) -> bool {
+        fn entries_correct_index(rbuf: &[Option<OrderedEntry>]) -> bool {
             for i in 0..rbuf.len() {
-                if rbuf[i].to_raw() != i as u32 + 1 && rbuf[i] != Self::NIL_VAL {
-                    return false;
+                if let Some(entry) = rbuf[i] {
+                    if entry.to_index() != i as u32 + 1 {
+                        return false;
+                    }
                 }
             }
             return true;
         }
 
         // Invariant: Check if entries all have correct index
-        fn double_entries_consistent(rbuf: &[OrderedEntry]) -> bool {
-            for i in 0..(rbuf.len() - 1) {
-                let cur = &rbuf[i];
-                let next = &rbuf[i + 1];
-                if (cur.is_prefix() && !next.is_suffix()) || (!cur.is_prefix() && next.is_suffix())
-                {
+        fn double_entries_consistent(rbuf: &[Option<OrderedEntry>]) -> bool {
+            if let Some(first_entry) = rbuf[0] {
+                if first_entry.is_suffix() {
                     return false;
+                }
+            }
+            if let Some(last_entry) = rbuf[rbuf.len() - 1] {
+                if last_entry.is_prefix_unchecked() {
+                    return false;
+                }
+            }
+            for i in 0..(rbuf.len() - 1) {
+                match rbuf[i] {
+                    None => {
+                        if let Some(next) = rbuf[i + 1] {
+                            if next.is_suffix() {
+                                return false;
+                            }
+                        }
+                    }
+                    Some(current) => {
+                        if current.is_prefix_unchecked() {
+                            if let Some(next) = rbuf[i + 1] {
+                                if !next.is_suffix() {
+                                    return false;
+                                }
+                            } else {
+                                return false;
+                            }
+                        }
+                    }
                 }
             }
             return true;
         }
     }
 
-    pub struct RawPtrSnapper<'a>(*const RaceBuffer<'a, OrderedEntry>);
+    pub struct RawPtrSnapper<'a>(*const writer::RaceBuffer<'a, OrderedEntry>);
 
-    impl Snapper<OrderedEntry> for RawPtrSnapper<'_> {
-        fn snap_wcurs(&self) -> usize {
-            unsafe { self.0.as_ref().unwrap().read_wcurs() }
+    impl reader::Snapper<OrderedEntry> for RawPtrSnapper<'_> {
+        fn snap_wcurs(&self) -> Result<usize, Box<dyn Error>> {
+            unsafe { Ok(self.0.as_ref().unwrap().read_wcurs()) }
         }
 
-        fn snap_storage(&self, index: usize) -> OrderedEntry {
-            unsafe { self.0.as_ref().unwrap().read_storage(index) }
+        fn snap_owcurs(&self) -> Result<usize, Box<dyn Error>> {
+            unsafe { Ok(self.0.as_ref().unwrap().read_owcurs()) }
+        }
+
+        fn snap_storage(&self, index: usize) -> Result<OrderedEntry, Box<dyn Error>> {
+            unsafe { Ok(self.0.as_ref().unwrap().read_storage(index)) }
         }
     }
 
-    #[test]
     // Perform many reads and writes concurrently,
     // check if read buffer is in order and consistent
+    #[test]
     fn test_basic() {
         const NUM_WRITES: u32 = 160;
-        const STORAGE_CAP: usize = 16;
+        const STORAGE_CAP: usize = 15;
 
         let (ptr_s, ptr_r) = crossbeam::crossbeam_channel::bounded(0);
         let barr_r = Arc::new(Barrier::new(2));
         let barr_w = barr_r.clone();
         crossbeam::thread::scope(|s| {
             s.spawn(move |_| {
-                let mut storage = [OrderedEntry::NIL_VAL; STORAGE_CAP];
+                let mut storage = [MaybeUninit::uninit(); STORAGE_CAP];
 
-                let mut buf = RaceBuffer::new(&mut storage[..]).unwrap();
-                let buf_ptr = &buf as *const RaceBuffer<'_, OrderedEntry> as usize;
+                let mut buf = writer::RaceBuffer::new(&mut storage[..], false);
+                assert!(buf.get_slice().len() == STORAGE_CAP);
+                let buf_ptr = &buf as *const writer::RaceBuffer<'_, OrderedEntry> as usize;
                 ptr_s.send(buf_ptr).unwrap();
 
                 for i in 1..=NUM_WRITES {
@@ -333,17 +179,17 @@ pub mod tests {
                 barr_r.wait();
             });
             s.spawn(move |_| {
-                let buf_ptr = ptr_r.recv().unwrap() as *const RaceBuffer<'_, OrderedEntry>;
+                let buf_ptr = ptr_r.recv().unwrap() as *const writer::RaceBuffer<'_, OrderedEntry>;
                 let snapper = RawPtrSnapper(buf_ptr);
                 let mut rbuf = Vec::new();
-                let mut reader = RaceBufferReader::new(snapper, STORAGE_CAP);
+                let mut buf_reader = reader::RaceBufferReader::new(snapper, STORAGE_CAP);
 
                 while rbuf.len() < NUM_WRITES as usize {
-                    reader.read(&mut rbuf);
+                    buf_reader.read(&mut rbuf).unwrap();
                     thread::sleep(Duration::from_millis(10));
                 }
                 thread::sleep(Duration::from_millis(100));
-                reader.read(&mut rbuf);
+                buf_reader.read(&mut rbuf).unwrap();
                 assert_eq!(rbuf.len(), NUM_WRITES as usize);
                 assert!(OrderedEntry::entries_correct_index(&rbuf[..]));
                 barr_w.wait();
@@ -352,11 +198,13 @@ pub mod tests {
         .unwrap();
     }
 
-    #[test]
     // Perform many reads and writes concurrently with random timeouts,
     // check if read buffer is in order and consistent
+    #[test]
     fn test_random() {
         const NUM_WRITES: u32 = 100_000;
+        const RAW_STORAGE_CAP: usize = 7;
+        // Rounded to nearest power of 2 below
         const STORAGE_CAP: usize = 4;
 
         let (ptr_s, ptr_r) = crossbeam::crossbeam_channel::bounded(0);
@@ -364,10 +212,11 @@ pub mod tests {
         let barr_w = barr_r.clone();
         crossbeam::thread::scope(|s| {
             s.spawn(move |_| {
-                let mut storage = [OrderedEntry::NIL_VAL; STORAGE_CAP];
+                let mut storage = [MaybeUninit::uninit(); RAW_STORAGE_CAP];
 
-                let mut buf = RaceBuffer::new(&mut storage[..]).unwrap();
-                let buf_ptr = &buf as *const RaceBuffer<'_, OrderedEntry> as usize;
+                let mut buf = writer::RaceBuffer::new(&mut storage[..], true);
+                assert!(buf.get_slice().len() == STORAGE_CAP);
+                let buf_ptr = &buf as *const writer::RaceBuffer<'_, OrderedEntry> as usize;
                 ptr_s.send(buf_ptr).unwrap();
 
                 let mut rng = rand::thread_rng();
@@ -391,21 +240,25 @@ pub mod tests {
                 barr_r.wait();
             });
             s.spawn(move |_| {
-                let buf_ptr = ptr_r.recv().unwrap() as *const RaceBuffer<'_, OrderedEntry>;
+                let buf_ptr = ptr_r.recv().unwrap() as *const writer::RaceBuffer<'_, OrderedEntry>;
                 let snapper = RawPtrSnapper(buf_ptr);
 
                 let mut rbuf = Vec::new();
-                let mut reader = RaceBufferReader::new(snapper, STORAGE_CAP);
+                let mut buf_reader = reader::RaceBufferReader::new(snapper, STORAGE_CAP);
 
                 let mut rng = rand::thread_rng();
-                while rbuf.len() < NUM_WRITES as usize {
-                    reader.read(&mut rbuf);
+                // Last write could be a prefix, only ensure read up to second to last write
+                while rbuf.len() < (NUM_WRITES - 1) as usize {
+                    buf_reader.read(&mut rbuf).unwrap();
                     let sleep_time: u64 = rng.gen::<u64>() % 3000;
                     std::thread::sleep(Duration::from_nanos(sleep_time));
                 }
                 thread::sleep(Duration::from_millis(100));
-                reader.read(&mut rbuf);
-                assert_eq!(rbuf.len(), NUM_WRITES as usize);
+                buf_reader.read(&mut rbuf).unwrap();
+                assert!(
+                    (rbuf.len() == NUM_WRITES as usize)
+                        || (rbuf.len() == (NUM_WRITES - 1) as usize)
+                );
                 assert!(OrderedEntry::entries_correct_index(&rbuf[..]));
                 assert!(OrderedEntry::double_entries_consistent(&rbuf[..]));
                 barr_w.wait();

--- a/race-buffer/src/reader.rs
+++ b/race-buffer/src/reader.rs
@@ -1,0 +1,139 @@
+use crate::{get_cursor_index, Entry};
+use core::marker::PhantomData;
+use std::cmp::min;
+use std::error::Error;
+
+type Result<T> = std::result::Result<T, Box<dyn Error>>;
+/// Used to "snap" observations of the RaceBuffer's write cursor
+/// or entries in the RaceBuffer's backing storage. Each Snapper access
+/// should have sequential consistency with the memory access of the RaceBuffer writer
+pub trait Snapper<E>
+where
+    E: Entry,
+{
+    /// Take a snapshot of the write cursor of the RaceBuffer
+    fn snap_wcurs(&self) -> Result<usize>;
+    /// Take a snapshot of the overwrite cursor of the RaceBuffer
+    fn snap_owcurs(&self) -> Result<usize>;
+    /// Take a snapshot of the RaceBuffer's backing storage at the given index
+    fn snap_storage(&self, index: usize) -> Result<E>;
+}
+
+/// Struct used to read from a RaceBuffer asynchronously
+pub struct RaceBufferReader<E, S>
+where
+    E: Entry,
+    S: Snapper<E>,
+{
+    /// Struct for reading writer state
+    snapper: S,
+    /// Reader's cursor
+    rcurs: usize,
+    /// Capacity of backing storage
+    storage_cap: usize,
+    /// Cached prefix, not put into buffer until suffix is successfully read
+    stored_prefix: Option<E>,
+    phantom: PhantomData<E>,
+}
+
+impl<E, S> RaceBufferReader<E, S>
+where
+    E: Copy + PartialEq + Entry,
+    S: Snapper<E>,
+{
+    /// Create new RaceBufferReader
+    pub fn new(snapper: S, storage_cap: usize) -> RaceBufferReader<E, S> {
+        RaceBufferReader {
+            snapper,
+            rcurs: 0,
+            storage_cap,
+            stored_prefix: None,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Attempt to read all new entries in race buffer into given read buffer
+    pub fn read(&mut self, rbuf: &mut Vec<Option<E>>) -> Result<()> {
+        let pre_wcurs = self.snapper.snap_wcurs()?;
+        let pre_owcurs = self.snapper.snap_owcurs()?;
+
+        if pre_owcurs > self.rcurs + self.storage_cap {
+            // If writer has overwritten unread entries between reads, store nils and correct rcurs
+            let num_missed = pre_owcurs - (self.rcurs + self.storage_cap);
+            self.store_missed_items(num_missed, rbuf);
+            self.rcurs = pre_owcurs - self.storage_cap;
+        }
+
+        // Perform reads into snapshot buffer up to write cursor
+        let first_read = self.rcurs;
+        let mut buf_snapshot: Vec<E> = Vec::new();
+        while self.rcurs < pre_wcurs {
+            let storage_index = get_cursor_index(self.storage_cap, self.rcurs, false);
+            buf_snapshot.push(self.snapper.snap_storage(storage_index)?);
+            self.rcurs += 1;
+        }
+
+        // Calculate number of entries in snapshot buffer that may have been overwritten
+        let post_owcurs = self.snapper.snap_owcurs()?;
+        let overlap = min(
+            if post_owcurs > self.storage_cap + first_read {
+                post_owcurs - (first_read + self.storage_cap)
+            } else {
+                0
+            },
+            buf_snapshot.len(),
+        );
+
+        if overlap != 0 {
+            self.store_missed_items(overlap, rbuf);
+        }
+
+        // Store valid entries in read buffer
+        for entry in &mut buf_snapshot[overlap..] {
+            self.store(*entry, rbuf);
+        }
+        Ok(())
+    }
+
+    /// Store given entry in given read buffer
+    #[inline]
+    fn store(&mut self, entry: E, rbuf: &mut Vec<Option<E>>) {
+        match self.stored_prefix {
+            None => {
+                if entry.is_prefix() {
+                    self.stored_prefix = Some(entry);
+                } else {
+                    rbuf.push(Some(entry));
+                }
+            }
+            Some(prefix) => {
+                rbuf.push(Some(prefix));
+                rbuf.push(Some(entry));
+                self.stored_prefix = None;
+            }
+        }
+    }
+
+    #[inline]
+    fn store_missed_item(&mut self, rbuf: &mut Vec<Option<E>>) {
+        match self.stored_prefix {
+            None => {
+                rbuf.push(None);
+            }
+            Some(_) => {
+                // Suffix missed, indicate 2 missed entries
+                rbuf.push(None);
+                rbuf.push(None);
+                self.stored_prefix = None;
+            }
+        }
+    }
+
+    #[inline]
+    /// Store given number of nil entries in given read buffer
+    fn store_missed_items(&mut self, num: usize, rbuf: &mut Vec<Option<E>>) {
+        for _ in 0..num {
+            self.store_missed_item(rbuf);
+        }
+    }
+}

--- a/race-buffer/src/writer.rs
+++ b/race-buffer/src/writer.rs
@@ -1,0 +1,168 @@
+use crate::{get_cursor_index, Entry};
+use core::iter::Iterator;
+use core::mem::size_of;
+use core::mem::MaybeUninit;
+
+pub enum ReadEntry<E>
+where
+    E: Entry,
+{
+    NotYetWritten,
+    Missed,
+    Entry(E),
+}
+
+#[inline]
+/// Round given length down to a power of 2
+fn round_to_power_2(length: usize) -> usize {
+    let exp: usize = size_of::<usize>() * 8 - (length.leading_zeros() as usize) - 1;
+    1 << exp
+}
+
+#[repr(C)]
+/// Struct used to write to buffer
+pub struct RaceBuffer<'a, E>
+where
+    E: Entry,
+{
+    /// Write cursor: Cursor pointing to where the next entry will be written
+    wcurs: usize,
+    /// Overwrite cursor: Entries in front of wcurs but behind owcurs are in the process of being overwritten
+    owcurs: usize,
+    /// Backing storage
+    storage: &'a mut [MaybeUninit<E>],
+    /// Indicates if backing storage should be truncated to a power of 2 length
+    /// in order to use optimized indexing
+    use_base_2_indexing: bool,
+}
+
+impl<'a, E> RaceBuffer<'a, E>
+where
+    E: Entry,
+{
+    /// Create new RaceBuffer. Returns error if storage size is not power of 2
+    pub fn new(storage: &'a mut [MaybeUninit<E>], use_base_2_indexing: bool) -> RaceBuffer<'a, E> {
+        let truncated_len = if use_base_2_indexing {
+            round_to_power_2(storage.len())
+        } else {
+            storage.len()
+        };
+        RaceBuffer {
+            wcurs: 0,
+            owcurs: 0,
+            storage: &mut storage[..truncated_len],
+            use_base_2_indexing,
+        }
+    }
+
+    /// Write single entry to buffer
+    pub fn write(&mut self, entry: E) {
+        if self.wcurs == self.owcurs {
+            // If overwriting double, increment overwrite cursor by 2
+            if self.wcurs >= self.storage.len()
+                && unsafe { self.read_storage(self.wcurs).is_prefix() }
+            {
+                self.owcurs += 2;
+            } else {
+                self.owcurs += 1;
+            }
+        }
+        self.write_to_storage(self.wcurs, entry);
+        self.wcurs += 1;
+    }
+
+    #[inline]
+    /// Get value of backing storage corresponding to given index
+    pub(crate) unsafe fn read_storage(&self, curs: usize) -> E {
+        self.storage[get_cursor_index(self.storage.len(), curs, self.use_base_2_indexing)]
+            .assume_init()
+    }
+
+    #[inline]
+    fn write_to_storage(&mut self, curs: usize, entry: E) {
+        self.storage[get_cursor_index(self.storage.len(), curs, self.use_base_2_indexing)] =
+            MaybeUninit::new(entry);
+    }
+
+    #[inline]
+    pub fn read(&self, curs: usize) -> ReadEntry<E> {
+        if self.wcurs <= curs {
+            ReadEntry::NotYetWritten
+        } else if self.owcurs > curs + self.storage.len() {
+            ReadEntry::Missed
+        } else {
+            ReadEntry::Entry(unsafe {
+                self.read_storage(get_cursor_index(
+                    self.storage.len(),
+                    curs,
+                    self.use_base_2_indexing,
+                ))
+            })
+        }
+    }
+
+    pub fn iter<'b>(&'b self, start_rcurs: usize) -> RaceBufferIter<'a, 'b, E> {
+        RaceBufferIter::new(self, start_rcurs)
+    }
+
+    #[cfg(feature = "std")]
+    #[cfg(test)]
+    #[inline]
+    /// Get current value of write cursor
+    pub(crate) fn read_wcurs(&self) -> usize {
+        self.wcurs
+    }
+
+    #[cfg(feature = "std")]
+    #[cfg(test)]
+    #[inline]
+    /// Get current value of write cursor
+    pub(crate) fn read_owcurs(&self) -> usize {
+        self.owcurs
+    }
+
+    #[cfg(feature = "std")]
+    #[cfg(test)]
+    #[inline]
+    pub(crate) fn get_slice(&self) -> &[MaybeUninit<E>] {
+        self.storage
+    }
+}
+
+pub struct RaceBufferIter<'a, 'b, E>
+where
+    E: Entry,
+{
+    race_buffer: &'b RaceBuffer<'a, E>,
+    rcurs: usize,
+}
+
+impl<'a, 'b, E> RaceBufferIter<'a, 'b, E>
+where
+    E: Entry,
+{
+    pub fn new(race_buffer: &'b RaceBuffer<'a, E>, start_curs: usize) -> Self {
+        Self {
+            race_buffer,
+            rcurs: start_curs,
+        }
+    }
+}
+
+impl<'a, 'b, E> Iterator for RaceBufferIter<'a, 'b, E>
+where
+    E: Entry,
+{
+    type Item = Option<E>;
+
+    fn next(&mut self) -> Option<Option<E>> {
+        match self.race_buffer.read(self.rcurs) {
+            ReadEntry::NotYetWritten => None,
+            ReadEntry::Missed => Some(None),
+            ReadEntry::Entry(e) => {
+                self.rcurs += 1;
+                Some(Some(e))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Update race buffer crate and TLA+ model to remove the need for reserved nil values. This was necessary because clock counts and payload items can take any u32 value, so it is impossible to reserve any CompactLogItem value as nil.