### PR TITLE
Do not allow self-merges, reorganize epoch calculation

### DIFF
--- a/modality-probe-capi/ctest/test.c
+++ b/modality-probe-capi/ctest/test.c
@@ -323,9 +323,8 @@ bool test_now(void) {
 
 static int g_next_seq_id = 100;
 static bool g_next_seq_id_fn_was_called = false;
-static uint16_t next_persistent_sequence_id(uint32_t probe_id, void *user_state)
+static size_t next_persistent_sequence_id(uint32_t probe_id, void *user_state, uint16_t* out_sequence_id)
 {
-
     assert(probe_id ==  DEFAULT_PROBE_ID);
     assert(user_state == (void*) 1);
     g_next_seq_id_fn_was_called = true;
@@ -333,7 +332,8 @@ static uint16_t next_persistent_sequence_id(uint32_t probe_id, void *user_state)
     const uint16_t next_seq_id = (uint16_t) g_next_seq_id;
     g_next_seq_id += 1;
     assert(next_seq_id != 0);
-    return next_seq_id;
+    *out_sequence_id = next_seq_id;
+    return MODALITY_PROBE_ERROR_OK;
 }
 
 bool test_persistent_restart_sequence_id(void) {

--- a/modality-probe-capi/ctest/test.c
+++ b/modality-probe-capi/ctest/test.c
@@ -325,6 +325,7 @@ static int g_next_seq_id = 100;
 static bool g_next_seq_id_fn_was_called = false;
 static uint16_t next_persistent_sequence_id(uint32_t probe_id, void *user_state)
 {
+
     assert(probe_id ==  DEFAULT_PROBE_ID);
     assert(user_state == (void*) 1);
     g_next_seq_id_fn_was_called = true;
@@ -340,6 +341,8 @@ bool test_persistent_restart_sequence_id(void) {
 
     uint8_t * destination = (uint8_t*)malloc(DEFAULT_PROBE_SIZE);
     modality_probe * probe;
+    int g_next_seq_id_cache = g_next_seq_id;
+
     modality_probe_error result = modality_probe_initialize(
             destination,
             DEFAULT_PROBE_SIZE,
@@ -361,6 +364,9 @@ bool test_persistent_restart_sequence_id(void) {
     free(destination);
 
     if (g_next_seq_id_fn_was_called != true) {
+        passed = false;
+    }
+    if (g_next_seq_id != g_next_seq_id_cache + 1) {
         passed = false;
     }
 

--- a/modality-probe-capi/include/probe.h
+++ b/modality-probe-capi/include/probe.h
@@ -80,15 +80,24 @@ typedef struct modality_probe_causal_snapshot {
  * epoch portion of the clock, and each time the ticks portion of the
  * clock overflows during the probe's lifetime.
  *
- * The sequence number should never be zero, should start at one,
+ *
+ * The function should return MODALITY_PROBE_ERROR_OK when the next
+ * sequence value could be retrieved and was used to populate the
+ * value at out_sequence_id.
+ *
+ * The sequence number starts at zero,
  * and be monotonically increased by a step size of one after each retrieval.
  *
  * When the sequence number reaches its maximum value (0xFFFF), it
- * should wrap around to the value 1.
+ * should wrap around to the value 0.
+ *
+ * If no sequence number could be retrieved, the function should
+ * return MODALITY_PROBE_ERROR_RESTART_PERSISTENCE_SEQUENCE_ID_UNAVAILABLE
  */
-typedef uint16_t (*modality_probe_next_sequence_id_fn)(
+typedef size_t (*modality_probe_next_sequence_id_fn)(
         uint32_t probe_id,
-        void *user_state);
+        void *user_state,
+        uint16_t *out_sequence_id);
 
 typedef enum {
     /*
@@ -134,6 +143,11 @@ typedef enum {
      * Detected during merging.
      */
     MODALITY_PROBE_ERROR_INVALID_EXTERNAL_HISTORY_SEMANTICS = 8,
+    /*
+     * The user-supplied restart persistence counter failed
+     * to produce the next sequence id.
+     */
+    MODALITY_PROBE_ERROR_RESTART_PERSISTENCE_SEQUENCE_ID_UNAVAILABLE = 9,
 } modality_probe_error;
 
 /*

--- a/modality-probe-capi/modality-probe-capi-impl/src/lib.rs
+++ b/modality-probe-capi/modality-probe-capi-impl/src/lib.rs
@@ -31,6 +31,9 @@ pub const MODALITY_PROBE_ERROR_INSUFFICIENT_SOURCE_BYTES: ModalityProbeError = 7
 /// such as by having a probe_id out of the allowed value range.
 /// Detected during merging.
 pub const MODALITY_PROBE_ERROR_INVALID_EXTERNAL_HISTORY_SEMANTICS: ModalityProbeError = 8;
+/// The user-supplied restart persistence counter failed
+/// to produce the next sequence id.
+pub const MODALITY_PROBE_ERROR_RESTART_PERSISTENCE_SEQUENCE_ID_UNAVAILABLE: ModalityProbeError = 9;
 
 /// # Safety
 ///

--- a/src/history.rs
+++ b/src/history.rs
@@ -55,7 +55,7 @@ const_assert_eq!(
         + size_of::<u32>()
         + size_of::<LogicalClock>()
         + size_of::<FixedSliceVec<'_, LogicalClock>>()
-        + size_of::<RestartSequenceCounter<'_>>()
+        + size_of::<RestartCounterProvider<'_>>()
         + size_of::<u64>(),
     size_of::<DynamicHistory>()
 );

--- a/src/history.rs
+++ b/src/history.rs
@@ -178,10 +178,13 @@ impl<'a> DynamicHistory<'a> {
         if clocks.capacity() < MIN_CLOCKS_LEN || (log.capacity() as usize) < MIN_LOG_LEN {
             return Err(StorageSetupError::UnderMinimumAllowedSize);
         }
+        let mut restart_counter = RestartSequenceCounter::new(restart_counter);
+        let (initial_epoch, restart_counter_had_error) =
+            DynamicHistory::calculate_next_epoch(&mut restart_counter, probe_id, None);
         clocks
             .try_push(LogicalClock {
                 id: probe_id,
-                epoch: ProbeEpoch(0),
+                epoch: initial_epoch,
                 ticks: ProbeTicks(0),
             })
             .expect(
@@ -193,16 +196,19 @@ impl<'a> DynamicHistory<'a> {
             event_count: 0,
             self_clock: LogicalClock {
                 id: probe_id,
-                epoch: ProbeEpoch(0),
+                epoch: initial_epoch,
                 ticks: ProbeTicks(0),
             },
             probe_id,
             clocks,
             log,
-            restart_counter: RestartSequenceCounter::new(restart_counter),
+            restart_counter,
         };
-        history.retreive_next_persistent_epoch();
         history.write_clocks_to_log(&[history.self_clock]);
+        history.record_event(EventId::EVENT_PROBE_INITIALIZED);
+        if restart_counter_had_error.0 {
+            history.record_event(EventId::EVENT_INVALID_NEXT_EPOCH_SEQ_ID);
+        }
         Ok(history)
     }
 
@@ -219,17 +225,35 @@ impl<'a> DynamicHistory<'a> {
         }
     }
 
-    fn retreive_next_persistent_epoch(&mut self) {
-        if self.restart_counter.is_tracking_restarts() {
-            match self.restart_counter.next_sequence_id(self.probe_id) {
-                Some(next_persistent_epoch) => {
-                    self.self_clock.epoch = next_persistent_epoch.get().into()
-                }
-                None => {
-                    self.self_clock.epoch = 0.into();
-                    self.record_event(EventId::EVENT_INVALID_NEXT_EPOCH_SEQ_ID);
-                }
+    /// Isolated function for figuring out what the next epoch should be for the probe.
+    fn calculate_next_epoch(
+        restart_counter: &mut RestartSequenceCounter,
+        probe_id: ProbeId,
+        prior_epoch: Option<ProbeEpoch>,
+    ) -> (ProbeEpoch, RestartCounterProvidedInvalidEpochSeqId) {
+        if restart_counter.is_tracking_restarts() {
+            if let Some(next_persistent_sequence_epoch) = restart_counter.next_sequence_id(probe_id)
+            {
+                (
+                    ProbeEpoch(next_persistent_sequence_epoch.get()),
+                    RestartCounterProvidedInvalidEpochSeqId(false),
+                )
+            } else {
+                (
+                    ProbeEpoch::MIN,
+                    RestartCounterProvidedInvalidEpochSeqId(true),
+                )
             }
+        } else if let Some(prior_epoch) = prior_epoch {
+            (
+                ProbeEpoch(core::cmp::max(1, prior_epoch.0.wrapping_add(1))),
+                RestartCounterProvidedInvalidEpochSeqId(false),
+            )
+        } else {
+            (
+                ProbeEpoch::MIN,
+                RestartCounterProvidedInvalidEpochSeqId(false),
+            )
         }
     }
 
@@ -263,18 +287,24 @@ impl<'a> DynamicHistory<'a> {
     /// Increments the clock in the logical clock corresponding to this probe instance
     #[inline]
     fn increment_local_clock(&mut self) {
-        // N.B. We rely on the fact that the first member of the clocks
-        // collection is always the clock for this probe
+        let original_epoch = self.self_clock.epoch;
         let did_overflow = self.self_clock.increment();
         self.event_count = 0;
 
         if did_overflow {
-            self.retreive_next_persistent_epoch();
-
+            let (fresh_epoch, restart_counter_had_error) = DynamicHistory::calculate_next_epoch(
+                &mut self.restart_counter,
+                self.probe_id,
+                Some(original_epoch),
+            );
+            self.self_clock.epoch = fresh_epoch;
             self.record_event_with_payload(
                 EventId::EVENT_LOGICAL_CLOCK_OVERFLOWED,
                 self.self_clock.epoch.0 as u32,
             );
+            if restart_counter_had_error.0 {
+                self.record_event(EventId::EVENT_INVALID_NEXT_EPOCH_SEQ_ID);
+            }
         }
     }
 
@@ -484,6 +514,13 @@ impl<'a> DynamicHistory<'a> {
         external_epoch: ProbeEpoch,
         external_clock: ProbeTicks,
     ) -> Result<(), MergeError> {
+        if external_id == self.probe_id {
+            // Quietly ignore self-snapshots in order to reduce complexity
+            // around divergence between the self-clock and the frontier set
+            // and to allow self-clocks in the log to remain the canonical
+            // logical-segment transition point.
+            return Ok(());
+        }
         self.increment_local_clock();
         self.write_clocks_to_log(&[
             self.self_clock,
@@ -534,6 +571,8 @@ impl<'a> DynamicHistory<'a> {
         Ok(())
     }
 }
+
+struct RestartCounterProvidedInvalidEpochSeqId(bool);
 
 #[cfg(test)]
 mod test {
@@ -675,7 +714,7 @@ mod test {
         let log_report = WireReport::new(&report_dest[..bytes_written.get()]).unwrap();
 
         assert_eq!(log_report.n_clocks() as usize, h.clocks.capacity());
-        assert_eq!(log_report.n_log_entries(), 19);
+        assert_eq!(log_report.n_log_entries(), 20);
 
         let offset = log_report.n_clocks() as usize * size_of::<LogicalClock>();
         let log_bytes = &log_report.payload()[offset..];
@@ -841,15 +880,236 @@ mod test {
         let h = DynamicHistory::new_at(&mut storage, probe_id, provider).unwrap();
 
         let now = h.now();
-        assert_eq!(now.clock.epoch.0, 0);
-        assert_eq!(now.clock.ticks.0, 0);
+        assert_eq!(now.clock.epoch, ProbeEpoch::MIN);
+        assert_eq!(now.clock.ticks, ProbeTicks::MIN);
 
         let mut found_error_event_count = 0;
-        while let Some(WholeEntry::Single(entry)) = h.log.pop() {
-            if entry.interpret_as_event_id() == Some(EventId::EVENT_INVALID_NEXT_EPOCH_SEQ_ID) {
-                found_error_event_count += 1;
+        while let Some(entry) = h.log.pop() {
+            match entry {
+                WholeEntry::Single(entry)
+                    if entry.interpret_as_event_id()
+                        == Some(EventId::EVENT_INVALID_NEXT_EPOCH_SEQ_ID) =>
+                {
+                    found_error_event_count += 1;
+                }
+                _ => (),
             }
         }
         assert_eq!(1, found_error_event_count);
+    }
+
+    mod now_tests {
+        use super::*;
+        #[test]
+        fn produce_and_merge_snapshot_ticks_clock() {
+            let probe_id = ProbeId::new(1).unwrap();
+            let mut storage = [0u8; 512];
+            let h = DynamicHistory::new_at(
+                &mut storage,
+                probe_id,
+                RestartCounterProvider::NoRestartTracking,
+            )
+            .unwrap();
+            let epoch = ProbeEpoch(0);
+
+            assert_eq!(
+                h.now(),
+                ModalityProbeInstant {
+                    clock: LogicalClock {
+                        id: probe_id,
+                        epoch,
+                        ticks: ProbeTicks(0)
+                    },
+                    event_count: 1
+                }
+            );
+
+            let local_snap_a = h.produce_snapshot();
+            assert_eq!(
+                local_snap_a,
+                CausalSnapshot {
+                    clock: LogicalClock {
+                        id: probe_id,
+                        epoch,
+                        ticks: ProbeTicks(0)
+                    },
+                    reserved_0: [0, 0],
+                    reserved_1: [0, 0]
+                }
+            );
+            assert_eq!(
+                h.now(),
+                ModalityProbeInstant {
+                    clock: LogicalClock {
+                        id: probe_id,
+                        epoch,
+                        ticks: ProbeTicks(1)
+                    },
+                    event_count: 0
+                }
+            );
+
+            let local_snap_b = h.produce_snapshot();
+            assert_eq!(
+                &local_snap_b,
+                &CausalSnapshot {
+                    clock: LogicalClock {
+                        id: probe_id,
+                        epoch,
+                        ticks: ProbeTicks(1)
+                    },
+                    reserved_0: [0, 0],
+                    reserved_1: [0, 0]
+                }
+            );
+            assert_eq!(
+                h.now(),
+                ModalityProbeInstant {
+                    clock: LogicalClock {
+                        id: probe_id,
+                        epoch,
+                        ticks: ProbeTicks(2)
+                    },
+                    event_count: 0
+                }
+            );
+
+            let remote_probe_id = ProbeId::new(probe_id.get_raw() + 1).unwrap();
+            let remote_snap = CausalSnapshot {
+                clock: LogicalClock {
+                    id: remote_probe_id,
+                    epoch,
+                    ticks: ProbeTicks(2),
+                },
+                reserved_0: [0, 0],
+                reserved_1: [0, 0],
+            };
+            h.merge_snapshot(&remote_snap).unwrap();
+            assert_eq!(
+                h.now(),
+                ModalityProbeInstant {
+                    clock: LogicalClock {
+                        id: probe_id,
+                        epoch,
+                        ticks: ProbeTicks(3)
+                    },
+                    event_count: 0
+                }
+            );
+        }
+        #[test]
+        fn record_events_ticks_event_counts() {
+            let probe_id = ProbeId::new(1).unwrap();
+            let mut storage = [0u8; 512];
+            let h = DynamicHistory::new_at(
+                &mut storage,
+                probe_id,
+                RestartCounterProvider::NoRestartTracking,
+            )
+            .unwrap();
+            let epoch = ProbeEpoch(0);
+
+            // event_count starts at 1 because of the EventId::EVENT_PROBE_INITIALIZED event
+            assert_eq!(
+                h.now(),
+                ModalityProbeInstant {
+                    clock: LogicalClock {
+                        id: probe_id,
+                        epoch,
+                        ticks: ProbeTicks(0)
+                    },
+                    event_count: 1
+                }
+            );
+            let event_id = EventId::new(456).unwrap();
+            h.record_event(event_id);
+            assert_eq!(
+                h.now(),
+                ModalityProbeInstant {
+                    clock: LogicalClock {
+                        id: probe_id,
+                        epoch,
+                        ticks: ProbeTicks(0)
+                    },
+                    event_count: 2
+                }
+            );
+            for _ in 0..8 {
+                h.record_event(event_id);
+            }
+            assert_eq!(
+                h.now(),
+                ModalityProbeInstant {
+                    clock: LogicalClock {
+                        id: probe_id,
+                        epoch,
+                        ticks: ProbeTicks(0)
+                    },
+                    event_count: 10
+                }
+            );
+
+            // A produce-induced clock tick resets the event count
+            let _ = h.produce_snapshot();
+            assert_eq!(
+                h.now(),
+                ModalityProbeInstant {
+                    clock: LogicalClock {
+                        id: probe_id,
+                        epoch,
+                        ticks: ProbeTicks(1)
+                    },
+                    event_count: 0
+                }
+            );
+            h.record_event(event_id);
+            assert_eq!(
+                h.now(),
+                ModalityProbeInstant {
+                    clock: LogicalClock {
+                        id: probe_id,
+                        epoch,
+                        ticks: ProbeTicks(1)
+                    },
+                    event_count: 1
+                }
+            );
+
+            // A merge-induced clock tick resets the event count
+            let remote_probe_id = ProbeId::new(probe_id.get_raw() + 1).unwrap();
+            let remote_snap = CausalSnapshot {
+                clock: LogicalClock {
+                    id: remote_probe_id,
+                    epoch,
+                    ticks: ProbeTicks(2),
+                },
+                reserved_0: [0, 0],
+                reserved_1: [0, 0],
+            };
+            h.merge_snapshot(&remote_snap).unwrap();
+            assert_eq!(
+                h.now(),
+                ModalityProbeInstant {
+                    clock: LogicalClock {
+                        id: probe_id,
+                        epoch,
+                        ticks: ProbeTicks(2)
+                    },
+                    event_count: 0
+                }
+            );
+            h.record_event(event_id);
+            assert_eq!(
+                h.now(),
+                ModalityProbeInstant {
+                    clock: LogicalClock {
+                        id: probe_id,
+                        epoch,
+                        ticks: ProbeTicks(2)
+                    },
+                    event_count: 1
+                }
+            );
+        }
     }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -244,7 +244,7 @@ impl<'a> DynamicHistory<'a> {
             }
         } else if let Some(prior_epoch) = prior_epoch {
             (
-                ProbeEpoch(core::cmp::max(1, prior_epoch.0.wrapping_add(1))),
+                ProbeEpoch(prior_epoch.0.wrapping_add(1)),
                 RestartCounterProvidedInvalidEpochSeqId(false),
             )
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use history::DynamicHistory;
 pub use id::*;
 pub use restart_counter::{
     next_sequence_id_fn, CRestartCounterProvider, RestartCounter, RestartCounterProvider,
-    RustRestartCounterProvider,
+    RestartSequenceIdUnavailable, RustRestartCounterProvider,
 };
 
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,13 +389,11 @@ impl<'a> ModalityProbe<'a> {
         probe_id: ProbeId,
         restart_counter: RestartCounterProvider<'a>,
     ) -> Result<ModalityProbe<'a>, StorageSetupError> {
-        let mut t = ModalityProbe::<'a> {
+        Ok(ModalityProbe::<'a> {
             fingerprint: Self::STRUCT_FINGERPRINT,
             fingerprint_padding: 0,
             history: DynamicHistory::new_at(history_memory, probe_id, restart_counter)?,
-        };
-        t.record_event(EventId::EVENT_PROBE_INITIALIZED);
-        Ok(t)
+        })
     }
 
     /// Record that an event occurred. The end user is responsible

--- a/src/restart_counter.rs
+++ b/src/restart_counter.rs
@@ -1,6 +1,5 @@
 use crate::ProbeId;
 use core::fmt;
-use core::num::NonZeroU16;
 
 /// A persistent restart sequence counter
 pub trait RestartCounter {
@@ -10,17 +9,36 @@ pub trait RestartCounter {
     /// epoch portion of the clock, and each time the ticks portion of the
     /// clock overflows during the probe's lifetime.
     ///
-    /// The sequence number should never be zero, should start at one,
-    /// and be monotonically increased by a step size of one after each retrieval.
+    /// The sequence number should start at zero, and be monotonically increased by a step size of
+    /// one after each retrieval.
     ///
     /// When the sequence number reaches its maximum value (0xFFFF), it
-    /// should wrap around to the value 1.
-    fn next_sequence_id(&mut self, probe_id: ProbeId) -> Option<NonZeroU16>;
+    /// should wrap around to the value 0.
+    fn next_sequence_id(&mut self, probe_id: ProbeId) -> Result<u16, RestartSequenceIdUnavailable>;
 }
 
-/// C function type for retrieving the next persistent sequence number
+/// Either:
+/// * The user-supplied restart persistence counter failed
+/// to produce the next sequence id.
+/// * No restart persistence strategy was provided by the user
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct RestartSequenceIdUnavailable;
+
+impl fmt::Debug for RestartSequenceIdUnavailable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("No restart sequence id could be produced")
+    }
+}
+
+/// C function type for retrieving the next persistent sequence number.
+/// Populates the next sequence number in `out_sequence_id`
+///
+/// Returns `MODALITY_PROBE_ERROR_OK` (0) when things are ok,
+/// and `MODALITY_PROBE_ERROR_RESTART_PERSISTENCE_SEQUENCE_ID_UNAVAILABLE` (9) when the
+/// next sequence number could not be determined.
 #[allow(non_camel_case_types)]
-pub type next_sequence_id_fn = extern "C" fn(u32, *mut core::ffi::c_void) -> u16;
+pub type next_sequence_id_fn =
+    extern "C" fn(probe_id: u32, state: *mut core::ffi::c_void, out_sequence_id: *mut u16) -> usize;
 
 /// A persistent restart sequence counter provider backed by a C implementation
 pub struct CRestartCounterProvider {
@@ -28,6 +46,23 @@ pub struct CRestartCounterProvider {
     pub iface: next_sequence_id_fn,
     /// User's state provided to the next_sequence_id_fn function call
     pub state: *mut core::ffi::c_void,
+}
+
+impl RestartCounter for CRestartCounterProvider {
+    fn next_sequence_id(&mut self, probe_id: ProbeId) -> Result<u16, RestartSequenceIdUnavailable> {
+        let mut out_sequence_number: u16 = 0;
+        let res = (self.iface)(
+            probe_id.get_raw(),
+            self.state,
+            &mut out_sequence_number as *mut u16,
+        );
+        // The "OK" case
+        if res == 0 {
+            Ok(out_sequence_number)
+        } else {
+            Err(RestartSequenceIdUnavailable)
+        }
+    }
 }
 
 /// A persistent restart sequence counter provider backed by a Rust implementation
@@ -47,45 +82,28 @@ pub enum RestartCounterProvider<'a> {
     Rust(RustRestartCounterProvider<'a>),
 }
 
+impl<'a> RestartCounterProvider<'a> {
+    /// Returns true if the user has provided some function at probe
+    /// initialization time which will be responsible for providing
+    /// a restart-persistence sequence number.
+    pub fn is_tracking_restarts(&self) -> bool {
+        !matches!(&self, RestartCounterProvider::NoRestartTracking)
+    }
+}
+
 impl<'a> From<&'a mut dyn RestartCounter> for RestartCounterProvider<'a> {
     fn from(r: &'a mut dyn RestartCounter) -> Self {
         RestartCounterProvider::Rust(RustRestartCounterProvider { iface: r })
     }
 }
 
-impl<'a> RestartCounterProvider<'a> {
-    fn next_sequence_id(&mut self, probe_id: ProbeId) -> Option<NonZeroU16> {
+impl<'a> RestartCounter for RestartCounterProvider<'a> {
+    fn next_sequence_id(&mut self, probe_id: ProbeId) -> Result<u16, RestartSequenceIdUnavailable> {
         match self {
-            RestartCounterProvider::NoRestartTracking => None,
-            RestartCounterProvider::C(c) => {
-                let raw = (c.iface)(probe_id.get_raw(), c.state);
-                debug_assert!(
-                    raw != 0,
-                    "A restart counter implementation should never return zero"
-                );
-                NonZeroU16::new(raw)
-            }
+            RestartCounterProvider::NoRestartTracking => Err(RestartSequenceIdUnavailable),
+            RestartCounterProvider::C(c) => c.next_sequence_id(probe_id),
             RestartCounterProvider::Rust(r) => r.iface.next_sequence_id(probe_id),
         }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct RestartSequenceCounter<'a> {
-    provider: RestartCounterProvider<'a>,
-}
-
-impl<'a> RestartSequenceCounter<'a> {
-    pub fn new(provider: RestartCounterProvider<'a>) -> Self {
-        RestartSequenceCounter { provider }
-    }
-
-    pub fn is_tracking_restarts(&self) -> bool {
-        !matches!(&self.provider, RestartCounterProvider::NoRestartTracking)
-    }
-
-    pub fn next_sequence_id(&mut self, probe_id: ProbeId) -> Option<NonZeroU16> {
-        self.provider.next_sequence_id(probe_id)
     }
 }
 
@@ -108,8 +126,11 @@ mod tests {
 
     #[test]
     fn no_restart_tracking() {
-        let mut rsc = RestartSequenceCounter::new(RestartCounterProvider::NoRestartTracking);
+        let mut rsc = RestartCounterProvider::NoRestartTracking;
         assert_eq!(rsc.is_tracking_restarts(), false);
-        assert_eq!(rsc.next_sequence_id(ProbeId::new(1).unwrap()), None);
+        assert_eq!(
+            rsc.next_sequence_id(ProbeId::new(1).unwrap()),
+            Err(RestartSequenceIdUnavailable)
+        );
     }
 }

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@
 set -ex
 
 cargo build --all
-cargo test --no-run --workspace --features "std"
+cargo test --workspace --features "std"
 cargo test --workspace
 
 (


### PR DESCRIPTION
* When merging, ignore snapshots with the same probe id as the merging probe.
* Only insert events relating to probe epoch calculation *after* the initial clock set gets written to the log
  * Make sure the PROBE_INITIALIZED event is the first event after the clocks in the log for a new probe
* Add some tests to confirm when and how we expect clock-ticks to be reflected in snapshots and now-retrieved instants.
* Put the next-epoch calculation for the probe in one spot,  `calculate_next_epoch` , with more limited mutability.
* Dispel magic on the 0-value for probe epochs as seen through the lens of the persistent restart counter interfaces
* Add an explicit error path for the restart counter interfaces