### PR TITLE
Templatize dot output in export cli

### DIFF
--- a/modality-probe-cli/Cargo.toml
+++ b/modality-probe-cli/Cargo.toml
@@ -48,6 +48,9 @@ path = "../"
 version = "1"
 features = ["derive"]
 
+[dependencies.serde_json]
+version = "1"
+
 [dependencies.nom]
 version = "5.0"
 default-features = false

--- a/modality-probe-cli/Cargo.toml
+++ b/modality-probe-cli/Cargo.toml
@@ -37,6 +37,7 @@ hex = "0.4"
 derivative = "2.1"
 err-derive = "0.2.4"
 colorous = "1.0.3"
+tinytemplate = "1.1.0"
 modality-probe-collector-common = { path = "../collectors/modality-probe-collector-common" }
 modality-probe-graph = { path = "../modality-probe-graph" }
 

--- a/modality-probe-cli/src/export/graph.rs
+++ b/modality-probe-cli/src/export/graph.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashSet, hash::Hash, iter::Peekable};
 
-use colorous::{Color, Gradient};
 use serde::{Deserialize, Serialize};
 use tinytemplate::TinyTemplate;
 use uuid::Uuid;
@@ -555,17 +554,5 @@ mod test {
             .dot(&cfg, "topo", templates::TOPO)
             .unwrap();
         assert!(dot.contains("one -> two"), dot);
-    }
-
-    #[test]
-    fn palette_doesnt_panic() {
-        let mut p = Palette::<f64, _>::new(colorous::CUBEHELIX);
-        for _ in 0..20 {
-            p.next();
-        }
-        let mut p = Palette::<usize, _>::new(colorous::TABLEAU10);
-        for _ in 0..20 {
-            p.next();
-        }
     }
 }

--- a/modality-probe-cli/src/export/graph.rs
+++ b/modality-probe-cli/src/export/graph.rs
@@ -230,7 +230,7 @@ fn graph_to_tree<'a>(
         let comp = ctx.components.entry(comp_name.clone()).or_insert_with(|| {
             cluster_idx += 1;
             Component {
-                cluster_idx: cluster_idx,
+                cluster_idx,
                 name: comp_name,
                 probes: ProbeSet::new(),
             }
@@ -239,7 +239,7 @@ fn graph_to_tree<'a>(
         let probe = comp.probes.entry(probe_name.clone()).or_insert_with(|| {
             cluster_idx += 1;
             Probe {
-                cluster_idx: cluster_idx,
+                cluster_idx,
                 name: probe_meta.map(|p| p.name.clone()).unwrap_or(probe_name),
                 is_known: probe_meta.is_some(),
                 meta: probe_meta,
@@ -502,7 +502,7 @@ mod test {
             .as_complete()
             .dot(&cfg, "complete", templates::COMPLETE)
             .unwrap();
-        assert!(dot.contains("one_one_1_0 -> two_two_1_2"), dot);
+        assert!(dot.contains("one_one_1_0 ->\n    two_two_1_2"), dot);
     }
 
     #[test]
@@ -536,7 +536,7 @@ mod test {
             .as_states()
             .dot(&cfg, "states", templates::STATES)
             .unwrap();
-        assert!(dot.contains("one -> two"), dot);
+        assert!(dot.contains("one_AT_one ->\n    two_AT_two"), dot);
     }
 
     #[test]

--- a/modality-probe-cli/src/export/graph.rs
+++ b/modality-probe-cli/src/export/graph.rs
@@ -1,7 +1,9 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt::Write,
+    hash::Hash,
     iter::Peekable,
+    ops::Deref,
 };
 
 use colorous::{Color, Gradient};
@@ -13,7 +15,10 @@ use modality_probe::{EventId, LogicalClock, ProbeId};
 use modality_probe_collector_common::{ReportIter, ReportLogEntry};
 use modality_probe_graph::{EventDigraph, Graph, GraphEvent};
 
-use super::{Cfg, ExportError};
+use super::{
+    templates::{Component, ComponentSet, EdgeSet, Probe, ProbeSet},
+    {Cfg, ExportError},
+};
 
 /// A row in the events.csv for a component.
 #[derive(PartialEq, Eq, Debug, Clone, Deserialize, Hash, Serialize)]
@@ -62,505 +67,87 @@ where
 }
 
 #[derive(Default)]
-pub(super) struct NodeAndEdgeLists<G, W> {
-    nodes: HashMap<G, W>,
-    edges: HashMap<(G, G), W>,
+pub(super) struct NodeAndEdgeLists<G, NW = (), EW = ()> {
+    nodes: HashMap<G, NW>,
+    edges: HashMap<(G, G), EW>,
 }
 
-impl NodeAndEdgeLists<GraphEvent, ()> {
-    /// pare down a complete graph into only trace clocks, which is to
-    /// say, only the interactions between probes.
-    pub fn into_interactions(self) -> NodeAndEdgeLists<(ProbeId, LogicalClock), u32> {
-        let mut nodes = HashMap::new();
-        for (n, _) in self.nodes.into_iter() {
-            let weight = nodes.entry((n.probe_id, n.clock)).or_insert(0);
-            *weight += 1;
-        }
+impl<G> NodeAndEdgeLists<G>
+where
+    G: Deref<Target = GraphEvent> + Hash + Eq,
+{
+    pub fn filter<'a, NF, EF>(&'a self, node_filter: NF, edge_filter: EF) -> NodeAndEdgeLists<&'a G>
+    where
+        NF: Fn(&'a G) -> bool,
+        EF: Fn(&'a G, &'a G) -> bool,
+    {
+        let nodes = self
+            .nodes
+            .iter()
+            .filter(|(n, _)| node_filter(n))
+            .map(|(n, _)| (n, ()))
+            .collect();
 
-        let mut edges = HashMap::new();
-        for ((s, t), _) in self.edges.into_iter() {
-            if s.probe_id != t.probe_id {
-                let weight = edges
-                    .entry(((s.probe_id, s.clock), (t.probe_id, t.clock)))
-                    .or_insert(0);
-                *weight += 1;
-            }
-        }
+        let edges = self
+            .edges
+            .iter()
+            .filter(|((s, t), _)| edge_filter(s, t))
+            .map(|((s, t), _)| ((s, t), ()))
+            .collect();
         NodeAndEdgeLists { nodes, edges }
     }
 
+    /// Pare down a complete graph into only trace clocks, which is to
+    /// say, only the interactions between probes.
+    pub fn as_interactions<'a>(&'a self) -> NodeAndEdgeLists<&'a G> {
+        let mut node_set = HashSet::new();
+        let mut edge_set = HashSet::new();
+        self.filter(
+            |n| node_set.insert((n.probe_id, n.clock)),
+            |s, t| {
+                s.probe_id != t.probe_id
+                    && edge_set.insert(((s.probe_id, s.clock), (t.probe_id, t.clock)))
+            },
+        )
+    }
+
     /// Pare down a complete graph into the event transitions.
-    pub fn into_states(self) -> NodeAndEdgeLists<(ProbeId, EventId), u32> {
-        let mut nodes = HashMap::new();
-        for (n, _) in self.nodes.into_iter() {
-            let weight = nodes.entry((n.probe_id, n.id)).or_insert(0);
-            *weight += 1;
-        }
-
-        let mut edges = HashMap::new();
-        for ((s, t), _) in self.edges.into_iter() {
-            let weight = edges
-                .entry(((s.probe_id, s.id), (t.probe_id, t.id)))
-                .or_insert(0);
-            *weight += 1;
-        }
-
-        NodeAndEdgeLists { nodes, edges }
+    pub fn into_states<'a>(&'a self) -> NodeAndEdgeLists<&'a G> {
+        let mut node_set = HashSet::new();
+        let mut edge_set = HashSet::new();
+        self.filter(
+            |n| node_set.insert((n.probe_id, n.id)),
+            |s, t| edge_set.insert(((s.probe_id, s.id), (t.probe_id, t.id))),
+        )
     }
 
     /// Pare down a complete graph into just the probes and their
     /// communication topology.
-    pub fn into_topology(self) -> NodeAndEdgeLists<ProbeId, u32> {
-        let mut nodes = HashMap::new();
-        for (n, _) in self.nodes.into_iter() {
-            let weight = nodes.entry(n.probe_id).or_insert(0);
-            *weight += 1;
-        }
-
-        let mut edges = HashMap::new();
-        for ((s, t), _) in self.edges.into_iter() {
-            if s.probe_id != t.probe_id {
-                let weight = edges.entry((s.probe_id, t.probe_id)).or_insert(0);
-                *weight += 1;
-            }
-        }
-
-        NodeAndEdgeLists { nodes, edges }
+    pub fn into_topology<'a>(&'a self) -> NodeAndEdgeLists<&'a G> {
+        let mut node_set = HashSet::new();
+        let mut edge_set = HashSet::new();
+        self.filter(
+            |n| node_set.insert(n.probe_id),
+            |s, t| edge_set.insert((s.probe_id, t.probe_id)),
+        )
     }
 
     /// Spit out a string containing dot code representing a complete
     /// graph.
-    pub fn to_dot(&self, cfg: &Cfg) -> Result<String, ExportError> {
-        use crate::export::templates::complete::*;
-
-        let mut ctx = Context {
-            components: ComponentSet::new(),
-            edges: EdgeSet::new(),
-        };
-
-        let mut comp_palette = Palette::<_, Gradient>::new(colorous::GREYS);
-        let mut probe_palette = Palette::<_, [Color; 10]>::new(colorous::TABLEAU10);
-
-        let mut cluster_idx = 0;
-        for (node, _) in self.nodes.iter() {
-            let (comp_name, probe_name) =
-                if let Some(pmeta) = cfg.probes.get(&node.probe_id.get_raw()) {
-                    let comp_id = pmeta.component_id.to_string();
-                    if let Some(cname) = cfg.component_names.get(&comp_id) {
-                        (cname.clone(), pmeta.name.clone())
-                    } else {
-                        (comp_id, pmeta.name.clone())
-                    }
-                } else {
-                    (
-                        "UNKNOWN".to_string(),
-                        format!("UNKNOWN_PROBE_{}", node.probe_id.get_raw()),
-                    )
-                };
-            let comp = ctx.components.entry(comp_name.clone()).or_insert_with(|| {
-                cluster_idx += 1;
-                Component {
-                    cluster_idx,
-                    name: comp_name,
-                    fill_color: format!("#{:x}", comp_palette.next()),
-                    probes: ProbeSet::new(),
-                }
-            });
-            let probe = comp.probes.entry(probe_name.clone()).or_insert_with(|| {
-                cluster_idx += 1;
-                Probe {
-                    cluster_idx,
-                    name: probe_name.clone(),
-                    raw_id: node.probe_id.get_raw(),
-                    fill_color: format!("#{:x}", probe_palette.next()),
-                    events: vec![],
-                }
-            });
-            if let Ok(emeta) = get_event_meta(cfg, &node.probe_id, &node.id) {
-                let payload = node.payload.and_then(|pl| {
-                    emeta
-                        .type_hint
-                        .as_ref()
-                        .and_then(|th| parsed_payload(&th, pl).ok())
-                });
-                probe.events.push(Event {
-                    is_known: true,
-                    probe_name: probe_name.clone(),
-                    has_payload: payload.is_some(),
-                    payload,
-                    meta: Some(emeta.clone()),
-                    raw_id: node.id.get_raw(),
-                    raw_probe_id: node.probe_id.get_raw(),
-                    seq: node.seq.0,
-                    seq_idx: node.seq_idx,
-                });
-            } else {
-                probe.events.push(Event {
-                    is_known: false,
-                    probe_name: probe_name.clone(),
-                    meta: None,
-                    has_payload: false,
-                    payload: None,
-                    raw_id: node.id.get_raw(),
-                    raw_probe_id: node.probe_id.get_raw(),
-                    seq: node.seq.0,
-                    seq_idx: node.seq_idx,
-                });
-            }
-        }
-
-        for ((s, t), _) in self.edges.iter() {
-            let from = {
-                let probe_name = if let Some(pmeta) = cfg.probes.get(&s.probe_id.get_raw()) {
-                    pmeta.name.clone()
-                } else {
-                    format!("UNKNOWN_PROBE_{}", s.probe_id.get_raw())
-                };
-                if let Ok(emeta) = get_event_meta(cfg, &s.probe_id, &s.id) {
-                    Event {
-                        is_known: true,
-                        probe_name: probe_name.clone(),
-                        meta: Some(emeta.clone()),
-                        raw_id: s.id.get_raw(),
-                        raw_probe_id: s.probe_id.get_raw(),
-                        seq: s.seq.0,
-                        seq_idx: s.seq_idx,
-                        // Payloads aren't needed for edge
-                        // enumeration.
-                        payload: None,
-                        has_payload: false,
-                    }
-                } else {
-                    Event {
-                        is_known: false,
-                        probe_name: probe_name.clone(),
-                        meta: None,
-                        raw_id: s.id.get_raw(),
-                        raw_probe_id: s.probe_id.get_raw(),
-                        seq: s.seq.0,
-                        seq_idx: s.seq_idx,
-                        // Payloads aren't needed for edge
-                        // enumeration.
-                        payload: None,
-                        has_payload: false,
-                    }
-                }
-            };
-            let to = {
-                let probe_name = if let Some(pmeta) = cfg.probes.get(&t.probe_id.get_raw()) {
-                    pmeta.name.clone()
-                } else {
-                    format!("UNKNOWN_PROBE_{}", s.probe_id.get_raw())
-                };
-                if let Ok(emeta) = get_event_meta(cfg, &t.probe_id, &t.id) {
-                    Event {
-                        is_known: true,
-                        probe_name: probe_name.clone(),
-                        meta: Some(emeta.clone()),
-                        raw_id: t.id.get_raw(),
-                        raw_probe_id: t.probe_id.get_raw(),
-                        seq: t.seq.0,
-                        seq_idx: t.seq_idx,
-                        // Payloads aren't needed for edge
-                        // enumeration.
-                        payload: None,
-                        has_payload: false,
-                    }
-                } else {
-                    Event {
-                        is_known: false,
-                        probe_name: probe_name.clone(),
-                        meta: None,
-                        raw_id: t.id.get_raw(),
-                        raw_probe_id: t.probe_id.get_raw(),
-                        seq: t.seq.0,
-                        seq_idx: t.seq_idx,
-                        // Payloads aren't needed for edge
-                        // enumeration.
-                        payload: None,
-                        has_payload: false,
-                    }
-                }
-            };
-
-            ctx.edges.insert(Edge { from, to });
-        }
-
+    pub fn to_dot(
+        &self,
+        cfg: &Cfg,
+        name: &'static str,
+        temp: &'static str,
+    ) -> Result<String, ExportError> {
+        let ctx = graph_to_tree(
+            self.nodes.keys().map(Deref::deref),
+            self.edges.keys().map(|(s, t)| (s.deref(), t.deref())),
+            cfg,
+        );
         let mut tt = TinyTemplate::new();
-        tt.add_template("complete", TEMP).unwrap();
-        Ok(tt.render("complete", &ctx).unwrap())
-    }
-}
-
-impl NodeAndEdgeLists<(ProbeId, LogicalClock), u32> {
-    /// Spit out dot code representing an interaction graph.
-    pub fn to_dot(&self, cfg: &Cfg) -> Result<String, ExportError> {
-        let mut out = String::new();
-        let mut comps = HashMap::new();
-        let mut probes = HashMap::new();
-
-        writeln!(out, "digraph G {{")?;
-        writeln!(out, "    node [ color = \"#ffffff\" style = filled ]")?;
-        writeln!(out, "    edge [ color = \"#ffffff\" ]")?;
-
-        for ((probe_id, clock), w) in self.nodes.iter() {
-            if let Some(pmeta) = cfg.probes.get(&probe_id.get_raw()) {
-                let comp = comps
-                    .entry(pmeta.component_id.to_string())
-                    .or_insert_with(HashSet::new);
-                comp.insert(pmeta.name.clone());
-                let probe = probes.entry(pmeta.name.clone()).or_insert_with(Vec::new);
-                probe.push(format!(
-                    "{}_{} [ label = \"{}_{}\" description = \"{}\" file = \"{}\" {} raw_probe_id = {} weight = {} ]",
-                    pmeta.name,
-                    modality_probe::pack_clock_word(clock.epoch, clock.ticks),
-                    pmeta.name,
-                    modality_probe::pack_clock_word(clock.epoch, clock.ticks),
-                    pmeta.description,
-                    pmeta.file,
-                    if pmeta.line.is_empty() {
-                        String::new()
-                    } else {
-                        format!("line = {}", pmeta.line)
-                    },
-                    probe_id.get_raw(),
-                    w
-                ));
-            } else {
-                let pname = format!("UNKNOWN_PROBE_{}", probe_id.get_raw());
-                let comp = comps
-                    .entry("UNKNOWN_COMPONENT".to_string())
-                    .or_insert_with(HashSet::new);
-                comp.insert(pname.clone());
-                let probe = probes.entry(pname).or_insert_with(Vec::new);
-                probe.push(format!(
-                    "UNKNOWN_PROBE_{}_{} [ label = \"UNKNOWN_PROBE_{}_{}\" raw_probe_id = {} ]",
-                    probe_id.get_raw(),
-                    modality_probe::pack_clock_word(clock.epoch, clock.ticks),
-                    probe_id.get_raw(),
-                    modality_probe::pack_clock_word(clock.epoch, clock.ticks),
-                    probe_id.get_raw(),
-                ));
-            }
-        }
-
-        write_comps_and_probes(&comps, &probes, cfg, &mut out)?;
-
-        for (((sprobe, sclock), (tprobe, tclock)), _) in self.edges.iter() {
-            let source_name = if let Some(meta) = cfg.probes.get(&sprobe.get_raw()) {
-                meta.name.clone()
-            } else {
-                format!("UNKNOWN_PROBE_{}", sprobe.get_raw())
-            };
-            let target_name = if let Some(meta) = cfg.probes.get(&tprobe.get_raw()) {
-                meta.name.clone()
-            } else {
-                format!("UNKNOWN_PROBE_{}", tprobe.get_raw())
-            };
-            writeln!(
-                out,
-                "    {}_{} -> {}_{}",
-                source_name,
-                modality_probe::pack_clock_word(sclock.epoch, sclock.ticks),
-                target_name,
-                modality_probe::pack_clock_word(tclock.epoch, tclock.ticks)
-            )?;
-        }
-
-        writeln!(out, "}}")?;
-        Ok(out)
-    }
-}
-
-impl NodeAndEdgeLists<(ProbeId, EventId), u32> {
-    /// Spit out dot code representing an event transition state
-    /// machine.
-    pub fn to_dot(&self, cfg: &Cfg) -> Result<String, ExportError> {
-        let mut out = String::new();
-        let mut comps = HashMap::new();
-        writeln!(out, "digraph G {{")?;
-        writeln!(out, "    node [ color = \"#ffffff\" style = filled ]")?;
-        writeln!(out, "    edge [ color = \"#ffffff\" ]")?;
-        for ((pid, eid), w) in self.nodes.iter() {
-            let (pname, comp) = if let Some(pmeta) = cfg.probes.get(&pid.get_raw()) {
-                (
-                    pmeta.name.clone(),
-                    comps
-                        .entry(pmeta.component_id.to_string())
-                        .or_insert_with(Vec::new),
-                )
-            } else {
-                (
-                    format!("UNKNOWN_PROBE_{}", pid.get_raw()),
-                    comps
-                        .entry("UNKNOWN_COMPONENT".to_string())
-                        .or_insert_with(Vec::new),
-                )
-            };
-            if let Ok(emeta) = get_event_meta(&cfg, pid, eid) {
-                comp.push(format!(
-                    "{}_AT_{} [ label = \"{} @ {}\" description = \"{}\" file = \"{}\" {} tags = \"{}\" raw_event_id = {} weight = {} ]",
-                    emeta.name,
-                    pname,
-                    emeta.name,
-                    pname,
-                    emeta.description,
-                    emeta.file,
-                    if emeta.line.is_empty() {
-                        String::new()
-                    } else {
-                        format!("line = {}", emeta.line)
-                    },
-                    emeta.tags,
-                    eid.get_raw(),
-                    w
-                ));
-            } else {
-                comp.push(format!(
-                    "UNKNOWN_EVENT_{}_AT_{} [ label = \"UNKNOWN_EVENT_{} @ {}\" raw_event_id = {} raw_probe_id = {} ]",
-                    eid.get_raw(),
-                    pname,
-                    eid.get_raw(),
-                    pname,
-                    eid.get_raw(),
-                    pid.get_raw(),
-                ));
-            }
-        }
-
-        let mut comp_palette = Palette::<f64, _>::new(colorous::CUBEHELIX);
-        for (c_idx, (id, comp)) in comps.iter().enumerate() {
-            writeln!(out, "    subgraph cluster_{} {{", c_idx)?;
-            writeln!(
-                out,
-                "        label = \"{}\"",
-                if let Some(n) = cfg.component_names.get(id) {
-                    n
-                } else {
-                    id
-                }
-            )?;
-            writeln!(out, "        fontcolor = \"#ffffff\"")?;
-            writeln!(out, "        style = filled")?;
-            writeln!(out, "        color = \"#{:x}\"", comp_palette.next())?;
-            for ev in comp {
-                writeln!(out, "        {}", ev)?;
-            }
-            writeln!(out, "    }}")?;
-        }
-
-        for (((sp, se), (tp, te)), w) in self.edges.iter() {
-            let source_probe = if let Some(pmeta) = cfg.probes.get(&sp.get_raw()) {
-                pmeta.name.clone()
-            } else {
-                format!("UNKNOWN_PROBE_{}", sp.get_raw())
-            };
-            let source_event = if let Ok(emeta) = get_event_meta(&cfg, sp, se) {
-                emeta.name.clone()
-            } else {
-                format!("UNKNOWN_EVENT_{}", se.get_raw())
-            };
-            let target_probe = if let Some(pmeta) = cfg.probes.get(&tp.get_raw()) {
-                pmeta.name.clone()
-            } else {
-                format!("UNKNOWN_PROBE_{}", tp.get_raw())
-            };
-            let target_event = if let Ok(emeta) = get_event_meta(&cfg, sp, te) {
-                emeta.name.clone()
-            } else {
-                format!("UNKNOWN_EVENT_{}", te.get_raw())
-            };
-            writeln!(
-                out,
-                "    {}_AT_{} -> {}_AT_{} [ weight = {} ]",
-                source_event, source_probe, target_event, target_probe, w
-            )?;
-        }
-
-        writeln!(out, "}}")?;
-        Ok(out)
-    }
-}
-
-impl NodeAndEdgeLists<ProbeId, u32> {
-    /// Spit out dot code representing a topology graph.
-    pub fn to_dot(&self, cfg: &Cfg) -> Result<String, ExportError> {
-        let mut out = String::new();
-
-        writeln!(out, "digraph G {{")?;
-        writeln!(out, "    node [ color = \"#ffffff\" style = filled ]")?;
-        writeln!(out, "    edge [ color = \"#ffffff\" ]")?;
-
-        let mut comps = HashMap::new();
-
-        for (node, w) in self.nodes.iter() {
-            if let Some(pmeta) = cfg.probes.get(&node.get_raw()) {
-                let comp = comps
-                    .entry(pmeta.component_id.to_string())
-                    .or_insert_with(Vec::new);
-                comp.push(format!(
-                    "{} [ label = \"{}\" description = \"{}\" file = \"{}\" line = {} raw_probe_id = {} weight = {} ]",
-                    pmeta.name,
-                    pmeta.name,
-                    pmeta.description,
-                    pmeta.file,
-                    pmeta.line,
-                    node.get_raw(),
-                    w
-            ));
-            } else {
-                let comp = comps
-                    .entry("UNKNOWN_COMPONENT".to_string())
-                    .or_insert_with(Vec::new);
-                comp.push(format!(
-                    "UNKNOWN_PROBE_{} [ label = \"UNKNOWN_PROBE_{}\" ]",
-                    node.get_raw(),
-                    node.get_raw()
-                ));
-            }
-        }
-
-        let mut comp_palette = Palette::<f64, _>::new(colorous::CUBEHELIX);
-        for (c_idx, (id, comp)) in comps.iter().enumerate() {
-            writeln!(out, "    subgraph cluster_{} {{", c_idx)?;
-            writeln!(
-                out,
-                "        label = \"{}\"",
-                if let Some(n) = cfg.component_names.get(id) {
-                    n
-                } else {
-                    id
-                }
-            )?;
-            writeln!(out, "        fontcolor = \"#ffffff\"")?;
-            writeln!(out, "        style = filled")?;
-            writeln!(out, "        color = \"#{:x}\"", comp_palette.next())?;
-            for ev in comp {
-                writeln!(out, "        {}", ev)?;
-            }
-            writeln!(out, "    }}")?;
-        }
-
-        for ((s, t), w) in self.edges.iter() {
-            let source_name = if let Some(pmeta) = cfg.probes.get(&s.get_raw()) {
-                pmeta.name.clone()
-            } else {
-                format!("UNKNOWN_PROBE_{}", s.get_raw())
-            };
-            let target_name = if let Some(pmeta) = cfg.probes.get(&t.get_raw()) {
-                pmeta.name.clone()
-            } else {
-                format!("UNKNOWN_PROBE_{}", t.get_raw())
-            };
-            writeln!(
-                out,
-                "    {} -> {} [ weight = {} ]",
-                source_name, target_name, w,
-            )?;
-        }
-
-        writeln!(out, "}}")?;
-        Ok(out)
+        tt.add_template(name, temp).unwrap();
+        Ok(tt.render(name, &ctx).unwrap())
     }
 }
 
@@ -638,45 +225,181 @@ impl Palette<usize, [Color; 10]> {
     }
 }
 
-fn write_comps_and_probes<W: Write>(
-    comps: &HashMap<String, HashSet<String>>,
-    probes: &HashMap<String, Vec<String>>,
+use super::templates::complete::Context;
+
+fn graph_to_tree<'a>(
+    nodes: impl Iterator<Item = &'a GraphEvent>,
+    edges: impl Iterator<Item = (&'a GraphEvent, &'a GraphEvent)>,
     cfg: &Cfg,
-    mut out: W,
-) -> Result<(), ExportError> {
-    let mut probe_palette = Palette::<f64, _>::new(colorous::CUBEHELIX);
-    let mut comp_palette = Palette::<f64, _>::new(colorous::GREYS);
-    for (c_idx, (comp, probe_names)) in comps.iter().enumerate() {
-        writeln!(out, "    subgraph cluster_{} {{", c_idx)?;
-        writeln!(
-            out,
-            "        label = \"{}\"",
-            if let Some(comp_name) = cfg.component_names.get(comp) {
-                comp_name
+) -> Context {
+    use crate::export::templates::complete::*;
+
+    let mut ctx = Context {
+        components: ComponentSet::new(),
+        edges: EdgeSet::new(),
+    };
+
+    let mut cluster_idx = 0;
+
+    for node in nodes {
+        let probe = update_comps_and_probes(node, &mut ctx.components, &cfg, &mut cluster_idx);
+
+        if let Ok(emeta) = get_event_meta(cfg, &node.probe_id, &node.id) {
+            let payload = node.payload.and_then(|pl| {
+                emeta
+                    .type_hint
+                    .as_ref()
+                    .and_then(|th| parsed_payload(&th, pl).ok())
+            });
+            probe.events.push(Event {
+                is_known: true,
+                probe_name: probe.name.clone(),
+                has_payload: payload.is_some(),
+                payload,
+                meta: Some(emeta.clone()),
+                raw_id: node.id.get_raw(),
+                raw_probe_id: node.probe_id.get_raw(),
+                seq: node.seq.0,
+                seq_idx: node.seq_idx,
+            });
+        } else {
+            probe.events.push(Event {
+                is_known: false,
+                probe_name: probe.name.clone(),
+                meta: None,
+                has_payload: false,
+                payload: None,
+                raw_id: node.id.get_raw(),
+                raw_probe_id: node.probe_id.get_raw(),
+                seq: node.seq.0,
+                seq_idx: node.seq_idx,
+            });
+        }
+    }
+
+    for (s, t) in edges {
+        let from = {
+            let probe_name = if let Some(pmeta) = cfg.probes.get(&s.probe_id.get_raw()) {
+                pmeta.name.clone()
             } else {
-                comp
-            }
-        )?;
-        writeln!(out, "        style = filled")?;
-        writeln!(out, "        color = \"#{:x}\"", comp_palette.next())?;
-        for (p_idx, probe_name) in probe_names.iter().enumerate() {
-            writeln!(out, "        subgraph cluster_{} {{", p_idx)?;
-            writeln!(out, "            label = \"{}\"", probe_name)?;
-            writeln!(out, "            fontcolor = \"#ffffff\"")?;
-            writeln!(out, "            rank = same")?;
-            writeln!(out, "            style = filled")?;
-            writeln!(out, "            color = \"#{:x}\"", probe_palette.next())?;
-            if let Some(evs) = probes.get(probe_name) {
-                for ev_line in evs {
-                    writeln!(out, "            {}", ev_line)?;
+                format!("UNKNOWN_PROBE_{}", s.probe_id.get_raw())
+            };
+            if let Ok(emeta) = get_event_meta(cfg, &s.probe_id, &s.id) {
+                Event {
+                    is_known: true,
+                    probe_name: probe_name.clone(),
+                    meta: Some(emeta.clone()),
+                    raw_id: s.id.get_raw(),
+                    raw_probe_id: s.probe_id.get_raw(),
+                    seq: s.seq.0,
+                    seq_idx: s.seq_idx,
+                    // Payloads aren't needed for edge
+                    // enumeration.
+                    payload: None,
+                    has_payload: false,
+                }
+            } else {
+                Event {
+                    is_known: false,
+                    probe_name: probe_name.clone(),
+                    meta: None,
+                    raw_id: s.id.get_raw(),
+                    raw_probe_id: s.probe_id.get_raw(),
+                    seq: s.seq.0,
+                    seq_idx: s.seq_idx,
+                    // Payloads aren't needed for edge
+                    // enumeration.
+                    payload: None,
+                    has_payload: false,
                 }
             }
-            writeln!(out, "}}")?;
-        }
-        writeln!(out, "}}")?;
+        };
+        let to = {
+            let probe_name = if let Some(pmeta) = cfg.probes.get(&t.probe_id.get_raw()) {
+                pmeta.name.clone()
+            } else {
+                format!("UNKNOWN_PROBE_{}", s.probe_id.get_raw())
+            };
+            if let Ok(emeta) = get_event_meta(cfg, &t.probe_id, &t.id) {
+                Event {
+                    is_known: true,
+                    probe_name: probe_name.clone(),
+                    meta: Some(emeta.clone()),
+                    raw_id: t.id.get_raw(),
+                    raw_probe_id: t.probe_id.get_raw(),
+                    seq: t.seq.0,
+                    seq_idx: t.seq_idx,
+                    // Payloads aren't needed for edge
+                    // enumeration.
+                    payload: None,
+                    has_payload: false,
+                }
+            } else {
+                Event {
+                    is_known: false,
+                    probe_name: probe_name.clone(),
+                    meta: None,
+                    raw_id: t.id.get_raw(),
+                    raw_probe_id: t.probe_id.get_raw(),
+                    seq: t.seq.0,
+                    seq_idx: t.seq_idx,
+                    // Payloads aren't needed for edge
+                    // enumeration.
+                    payload: None,
+                    has_payload: false,
+                }
+            }
+        };
+
+        ctx.edges.insert(Edge { from, to });
     }
-    Ok(())
+    ctx
 }
+
+fn update_comps_and_probes<'a, E: Serialize>(
+    node: &'a GraphEvent,
+    comps: &'a mut ComponentSet<E>,
+    cfg: &Cfg,
+    cluster_idx: &mut usize,
+) -> &'a mut Probe<E> {
+    let mut comp_palette = Palette::<_, Gradient>::new(colorous::GREYS);
+    let mut probe_palette = Palette::<_, [Color; 10]>::new(colorous::TABLEAU10);
+
+    let (comp_name, probe_name) = if let Some(pmeta) = cfg.probes.get(&node.probe_id.get_raw()) {
+        let comp_id = pmeta.component_id.to_string();
+        if let Some(cname) = cfg.component_names.get(&comp_id) {
+            (cname.clone(), pmeta.name.clone())
+        } else {
+            (comp_id, pmeta.name.clone())
+        }
+    } else {
+        (
+            "UNKNOWN".to_string(),
+            format!("UNKNOWN_PROBE_{}", node.probe_id.get_raw()),
+        )
+    };
+    let comp = comps.entry(comp_name.clone()).or_insert_with(|| {
+        *cluster_idx += 1;
+        Component {
+            cluster_idx: *cluster_idx,
+            name: comp_name,
+            fill_color: format!("#{:x}", comp_palette.next()),
+            probes: ProbeSet::new(),
+        }
+    });
+    let probe = comp.probes.entry(probe_name.clone()).or_insert_with(|| {
+        *cluster_idx += 1;
+        Probe {
+            cluster_idx: *cluster_idx,
+            name: probe_name.clone(),
+            raw_id: node.probe_id.get_raw(),
+            fill_color: format!("#{:x}", probe_palette.next()),
+            events: vec![],
+        }
+    });
+    probe
+}
+
 #[cfg(test)]
 mod test {
     use std::convert::TryInto;
@@ -812,44 +535,44 @@ mod test {
         assert!(dot.contains("one_one_1_0 -> two_two_1_2"), dot);
     }
 
-    #[test]
-    fn interactions_dot() {
-        let cfg = cfg();
-        let diamond_log = modality_probe_graph::test_support::diamond()
-            .into_iter()
-            .map(|e| (&e).try_into().unwrap())
-            .peekable();
-        let graph = super::log_to_graph(diamond_log).unwrap();
+    // #[test]
+    // fn interactions_dot() {
+    //     let cfg = cfg();
+    //     let diamond_log = modality_probe_graph::test_support::diamond()
+    //         .into_iter()
+    //         .map(|e| (&e).try_into().unwrap())
+    //         .peekable();
+    //     let graph = super::log_to_graph(diamond_log).unwrap();
 
-        let dot = graph.graph.into_interactions().to_dot(&cfg).unwrap();
-        assert!(dot.contains("one_0 -> two_1"), dot);
-    }
+    //     let dot = graph.graph.into_interactions().to_dot(&cfg).unwrap();
+    //     assert!(dot.contains("one_0 -> two_1"), dot);
+    // }
 
-    #[test]
-    fn states_dot() {
-        let cfg = cfg();
-        let diamond_log = modality_probe_graph::test_support::diamond()
-            .into_iter()
-            .map(|e| (&e).try_into().unwrap())
-            .peekable();
-        let graph = super::log_to_graph(diamond_log).unwrap();
+    // #[test]
+    // fn states_dot() {
+    //     let cfg = cfg();
+    //     let diamond_log = modality_probe_graph::test_support::diamond()
+    //         .into_iter()
+    //         .map(|e| (&e).try_into().unwrap())
+    //         .peekable();
+    //     let graph = super::log_to_graph(diamond_log).unwrap();
 
-        let dot = graph.graph.into_states().to_dot(&cfg).unwrap();
-        assert!(dot.contains("one -> two"), dot);
-    }
+    //     let dot = graph.graph.into_states().to_dot(&cfg).unwrap();
+    //     assert!(dot.contains("one -> two"), dot);
+    // }
 
-    #[test]
-    fn topo_dot() {
-        let cfg = cfg();
-        let diamond_log = modality_probe_graph::test_support::diamond()
-            .into_iter()
-            .map(|e| (&e).try_into().unwrap())
-            .peekable();
-        let graph = super::log_to_graph(diamond_log).unwrap();
+    // #[test]
+    // fn topo_dot() {
+    //     let cfg = cfg();
+    //     let diamond_log = modality_probe_graph::test_support::diamond()
+    //         .into_iter()
+    //         .map(|e| (&e).try_into().unwrap())
+    //         .peekable();
+    //     let graph = super::log_to_graph(diamond_log).unwrap();
 
-        let dot = graph.graph.into_topology().to_dot(&cfg).unwrap();
-        assert!(dot.contains("one -> two"), dot);
-    }
+    //     let dot = graph.graph.into_topology().to_dot(&cfg).unwrap();
+    //     assert!(dot.contains("one -> two"), dot);
+    // }
 
     #[test]
     fn palette_doesnt_panic() {

--- a/modality-probe-cli/src/export/graph.rs
+++ b/modality-probe-cli/src/export/graph.rs
@@ -104,7 +104,7 @@ impl NodeAndEdgeLists<GraphEvent> {
         let mut edge_set = HashSet::new();
         self.filter(
             |n| node_set.insert(n.probe_id),
-            |s, t| edge_set.insert((s.probe_id, t.probe_id)),
+            |s, t| s.probe_id != t.probe_id && edge_set.insert((s.probe_id, t.probe_id)),
         )
     }
 

--- a/modality-probe-cli/src/export/mod.rs
+++ b/modality-probe-cli/src/export/mod.rs
@@ -91,10 +91,34 @@ pub fn run(mut exp: Export) -> Result<(), ExportError> {
     )?;
 
     match (exp.graph_type, exp.interactions_only) {
-        (GraphType::Acyclic, false) => println!("{}", graph.graph.to_dot(&cfg)?),
-        (GraphType::Acyclic, true) => println!("{}", graph.graph.into_interactions().to_dot(&cfg)?),
-        (GraphType::Cyclic, false) => println!("{}", graph.graph.into_states().to_dot(&cfg)?),
-        (GraphType::Cyclic, true) => println!("{}", graph.graph.into_topology().to_dot(&cfg)?),
+        (GraphType::Acyclic, false) => println!(
+            "{}",
+            graph
+                .graph
+                .as_complete()
+                .dot(&cfg, "complete", templates::COMPLETE)?
+        ),
+        (GraphType::Acyclic, true) => println!(
+            "{}",
+            graph
+                .graph
+                .as_interactions()
+                .dot(&cfg, "interactions", templates::INTERACTIONS)?
+        ),
+        (GraphType::Cyclic, false) => println!(
+            "{}",
+            graph
+                .graph
+                .as_states()
+                .dot(&cfg, "states", templates::STATES)?
+        ),
+        (GraphType::Cyclic, true) => println!(
+            "{}",
+            graph
+                .graph
+                .as_topology()
+                .dot(&cfg, "topo", templates::TOPO)?
+        ),
     }
 
     Ok(())

--- a/modality-probe-cli/src/export/mod.rs
+++ b/modality-probe-cli/src/export/mod.rs
@@ -11,6 +11,8 @@ use modality_probe_collector_common::{json, Error as CollectorError};
 
 use crate::{component::Component, events::Events};
 
+mod templates;
+
 mod graph;
 use graph::{EventMeta, ProbeMeta};
 

--- a/modality-probe-cli/src/export/templates.rs
+++ b/modality-probe-cli/src/export/templates.rs
@@ -216,7 +216,7 @@ pub fn gradient_color_formatter(
     Ok(())
 }
 
-pub const COMPLETE: &'static str = "digraph G \\{
+pub const COMPLETE: &str = "digraph G \\{
     node [ color = \"#ffffff\" style = filled ]
     edge [ color = \"#ffffff\" ]
     {{ for comp in components }}
@@ -263,7 +263,7 @@ pub const COMPLETE: &'static str = "digraph G \\{
     {{ endfor }}
 }";
 
-pub const INTERACTIONS: &'static str = "digraph G \\{
+pub const INTERACTIONS: &str = "digraph G \\{
     node [ color = \"#ffffff\" style = filled ]
     edge [ color = \"#ffffff\" ]
     {{ for comp in components }}
@@ -280,18 +280,22 @@ pub const INTERACTIONS: &'static str = "digraph G \\{
             color = \"{ probe.name | discrete_color_formatter }\"
             {{ for event in probe.events }}
             { event.probe_name }_{ event.clock } [
-                {{if event.is_known }}label        = \"{ event.meta.name }\"
+                {{if event.is_known }}
+                label        = \"{ event.meta.name }\"
                 description  = \"{ event.meta.description }\"
                 file         = \"{ event.meta.file }\"
                 probe        = \"{ event.probe_name }\"
-                tags         = \"{ event.meta.tags }\"{{ if event.has_payload }}
-                payload      = { event.payload }{{ endif }}
+                tags         = \"{ event.meta.tags }\"
+                {{ if event.has_payload }}
+                payload      = { event.payload }
+                {{ endif }}
                 raw_event_id = { event.raw_id }
-                raw_probe_id = { event.raw_probe_id }{{ else }}
+                raw_probe_id = { event.raw_probe_id }
+                {{ else }}
                 label        = \"UNKNOWN_EVENT_{ event.raw_id }\"
                 probe        = \"{ event.probe_name }\"
                 raw_event_id = { event.raw_id }
-                raw_probe_id = { event.raw_probe_id } {{ endif }}
+                raw_probe_id = { event.raw_probe_id }{{ endif }}
             ];
             {{ endfor}}
         }
@@ -304,7 +308,7 @@ pub const INTERACTIONS: &'static str = "digraph G \\{
     {{ endfor }}
 }";
 
-pub const STATES: &'static str = "digraph G \\{
+pub const STATES: &str = "digraph G \\{
     node [ color = \"#ffffff\" style = filled ]
     edge [ color = \"#ffffff\" ]
     {{ for comp in components }}
@@ -342,11 +346,11 @@ pub const STATES: &'static str = "digraph G \\{
     {{ endfor }}
 
     {{ for edge in edges }}
-    {{ if edge.from.is_known }}{ edge.from.meta.name }{{ else }}UNKNOWN_EVENT_{ event.raw_id }{{ endif }}_AT_{ edge.from.probe_name } ->
-    {{ if edge.to.is_known }}{ edge.to.meta.name }{{ else }}UNKNOWN_EVENT_{ event.raw_id }{{ endif }}_AT_{ edge.to.probe_name }
+    {{ if edge.from.is_known }}{ edge.from.meta.name }{{ else }}UNKNOWN_EVENT_{ edge.from.raw_id }{{ endif }}_AT_{ edge.from.probe_name } ->
+    {{ if edge.to.is_known }}{ edge.to.meta.name }{{ else }}UNKNOWN_EVENT_{ edge.to.raw_id }{{ endif }}_AT_{ edge.to.probe_name }
     {{ endfor }}
 }";
-pub const TOPO: &'static str = "digraph G \\{
+pub const TOPO: &str = "digraph G \\{
     edge [ color = \"#ffffff\" ]
     {{ for comp in components }}
     subgraph cluster_{ comp.cluster_idx } \\{

--- a/modality-probe-cli/src/export/templates.rs
+++ b/modality-probe-cli/src/export/templates.rs
@@ -302,5 +302,45 @@ pub const INTERACTIONS: &'static str = "digraph G \\{
     {{ endfor }}
 }";
 
-pub const STATES: &'static str = "";
-pub const TOPO: &'static str = "";
+pub const STATES: &'static str = "digraph G \\{
+    node [ color = \"#ffffff\" style = filled ]
+    edge [ color = \"#ffffff\" ]
+    {{ for comp in components }}
+    subgraph cluster_{ comp.cluster_idx } \\{
+        label = \"{ comp.name }\"
+        style = filled
+        color = \"{ comp.name | gradient_color_formatter }\"
+        {{ for probe in comp.probes }}
+        subgraph cluster_{ probe.cluster_idx } \\{
+            label = \"{ probe.name }\"
+            fontcolor = \"#ffffff\"
+            rank = same
+            style = filled
+            color = \"{ probe.name | discrete_color_formatter }\"
+            {{ for event in probe.events }}
+            {{ if event.is_known }}{ event.meta.name }_AT_{ event.probe_name } [
+                label        = \"{ event.meta.name } @ {event.probe_name }\"
+                description  = \"{ event.meta.description }\"
+                file         = \"{ event.meta.file }\"
+                probe        = \"{ event.probe_name }\"
+                tags         = \"{ event.meta.tags }\"{{ if event.has_payload }}
+                payload      = { event.payload }{{ endif }}
+                raw_event_id = { event.raw_id }
+                raw_probe_id = { event.raw_probe_id }
+            {{ else }}UNKNOWN_EVENT_{ event.raw_id }_AT_{ event.probe_name } [
+                label        = \"UNKNOWN_EVENT_{ event.raw_id } @ { event.probe_name }\"
+                probe        = \"{ event.probe_name }\"
+                raw_event_id = { event.raw_id }
+                raw_probe_id = { event.raw_probe_id } {{ endif }}
+            ];
+            {{ endfor}}
+        }
+        {{ endfor }}
+    }
+    {{ endfor }}
+
+    {{ for edge in edges }}
+    {{ if edge.from.is_known }}{ edge.from.meta.name }{{ else }}UNKNOWN_EVENT_{ event.raw_id }{{ endif }}_AT_{ edge.from.probe_name } ->
+    {{ if edge.to.is_known }}{ edge.to.meta.name }{{ else }}UNKNOWN_EVENT_{ event.raw_id }{{ endif }}_AT_{ edge.to.probe_name }
+    {{ endfor }}
+}";

--- a/modality-probe-cli/src/export/templates.rs
+++ b/modality-probe-cli/src/export/templates.rs
@@ -1,31 +1,219 @@
-pub mod complete {
-    use std::{
-        collections::{HashMap, HashSet},
-        ops::{Deref, DerefMut},
-    };
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Write,
+    ops::{Deref, DerefMut},
+};
 
-    use serde::{
-        ser::{SerializeSeq, Serializer},
-        Serialize,
-    };
+use serde::{
+    ser::{SerializeSeq, Serializer},
+    Serialize,
+};
+use serde_json::Value;
 
-    use crate::export::graph::EventMeta;
+use super::graph::EventMeta;
 
-    pub const TEMP: &'static str = "digraph G \\{
+#[derive(Serialize)]
+pub struct Component<E: Serialize> {
+    pub cluster_idx: usize,
+    pub name: String,
+    pub probes: ProbeSet<E>,
+}
+
+#[derive(Serialize)]
+pub struct Probe<E: Serialize> {
+    pub cluster_idx: usize,
+    pub name: String,
+    pub raw_id: u32,
+    pub events: Vec<E>,
+}
+pub struct ComponentSet<E: Serialize>(HashMap<String, Component<E>>);
+
+impl<E: Serialize> ComponentSet<E> {
+    pub fn new() -> Self {
+        ComponentSet(HashMap::new())
+    }
+}
+
+impl<E: Serialize> Serialize for ComponentSet<E> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.values().len()))?;
+        for comp in self.0.values() {
+            seq.serialize_element(comp)?
+        }
+        seq.end()
+    }
+}
+
+impl<E: Serialize> Deref for ComponentSet<E> {
+    type Target = HashMap<String, Component<E>>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<E: Serialize> DerefMut for ComponentSet<E> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+pub struct ProbeSet<E: Serialize>(HashMap<String, Probe<E>>);
+
+impl<E: Serialize> ProbeSet<E> {
+    pub fn new() -> Self {
+        ProbeSet(HashMap::new())
+    }
+}
+
+impl<E: Serialize> Serialize for ProbeSet<E> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.values().len()))?;
+        for probe in self.0.values() {
+            seq.serialize_element(probe)?
+        }
+        seq.end()
+    }
+}
+
+impl<E: Serialize> Deref for ProbeSet<E> {
+    type Target = HashMap<String, Probe<E>>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<E: Serialize> DerefMut for ProbeSet<E> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+pub struct EdgeSet<E: Serialize>(HashSet<E>);
+
+impl<E: Serialize> EdgeSet<E> {
+    pub fn new() -> Self {
+        EdgeSet(HashSet::new())
+    }
+}
+
+impl<E: Serialize> Deref for EdgeSet<E> {
+    type Target = HashSet<E>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<E: Serialize> DerefMut for EdgeSet<E> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<E: Serialize> Serialize for EdgeSet<E> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for edge in self.0.iter() {
+            seq.serialize_element(&edge)?
+        }
+        seq.end()
+    }
+}
+
+#[derive(Serialize)]
+pub struct Context {
+    pub components: ComponentSet<Event>,
+    pub edges: EdgeSet<Edge>,
+}
+
+#[derive(Hash, PartialEq, Eq, Serialize)]
+pub struct Event {
+    pub is_known: bool,
+    pub meta: Option<EventMeta>,
+    pub has_payload: bool,
+    pub payload: Option<String>,
+    pub raw_id: u32,
+    pub raw_probe_id: u32,
+    pub probe_name: String,
+    pub clock: u32,
+    pub seq: u64,
+    pub seq_idx: usize,
+}
+
+#[derive(PartialEq, Eq, Hash, Serialize)]
+pub struct Edge {
+    pub from: Event,
+    pub to: Event,
+}
+
+pub fn discrete_color_formatter(
+    val: &Value,
+    out: &mut String,
+) -> Result<(), tinytemplate::error::Error> {
+    match val {
+        Value::Number(n) => {
+            if n.is_u64() {
+                let c = colorous::TABLEAU10[(n.as_u64().unwrap() % 10) as usize];
+                write!(out, "#{:x}", c)?;
+                Ok(())
+            } else {
+                Err(tinytemplate::error::Error::GenericError {
+                    msg: "invalid value given to discrete_color_formatter".to_string(),
+                })
+            }
+        }
+        _ => Err(tinytemplate::error::Error::GenericError {
+            msg: "invalid value given to discrete_color_formatter".to_string(),
+        }),
+    }
+}
+
+pub fn gradient_color_formatter(
+    val: &Value,
+    out: &mut String,
+) -> Result<(), tinytemplate::error::Error> {
+    match val {
+        Value::Number(n) => {
+            if n.is_u64() {
+                let c = colorous::GREYS;
+                let n_float = n.as_u64().unwrap() as f64;
+                write!(out, "#{:x}", c.eval_continuous((n_float % 10.0) / 10.0))?;
+                Ok(())
+            } else {
+                Err(tinytemplate::error::Error::GenericError {
+                    msg: "invalid value given to discrete_color_formatter".to_string(),
+                })
+            }
+        }
+        _ => Err(tinytemplate::error::Error::GenericError {
+            msg: "invalid value given to discrete_color_formatter".to_string(),
+        }),
+    }
+}
+
+pub const COMPLETE: &'static str = "digraph G \\{
     node [ color = \"#ffffff\" style = filled ]
     edge [ color = \"#ffffff\" ]
     {{ for comp in components }}
     subgraph cluster_{ comp.cluster_idx } \\{
         label = \"{ comp.name }\"
         style = filled
-        color = \"{ comp.fill_color }\"
+        color = \"{ @index | gradient_color_formatter }\"
         {{ for probe in comp.probes }}
         subgraph cluster_{ probe.cluster_idx } \\{
             label = \"{ probe.name }\"
             fontcolor = \"#ffffff\"
             rank = same
             style = filled
-            color = \"{ probe.fill_color }\"
+            color = \"{ @index | discrete_color_formatter }\"
             {{ for event in probe.events }}
             {{ if event.is_known }}
             { event.meta.name }_{ event.probe_name }_{ event.seq }_{ event.seq_idx } [
@@ -58,147 +246,46 @@ pub mod complete {
     {{ endfor }}
 }";
 
-    pub struct ComponentSet(HashMap<String, Component>);
-
-    impl ComponentSet {
-        pub fn new() -> Self {
-            ComponentSet(HashMap::new())
+pub const INTERACTIONS: &'static str = "digraph G \\{
+    node [ color = \"#ffffff\" style = filled ]
+    edge [ color = \"#ffffff\" ]
+    {{ for comp in components }}
+    subgraph cluster_{ comp.cluster_idx } \\{
+        label = \"{ comp.name }\"
+        style = filled
+        color = \"{ @index | gradient_color_formatter }\"
+        {{ for probe in comp.probes }}
+        subgraph cluster_{ probe.cluster_idx } \\{
+            label = \"{ probe.name }\"
+            fontcolor = \"#ffffff\"
+            rank = same
+            style = filled
+            color = \"{ @index | discrete_color_formatter }\"
+            {{ for event in probe.events }}
+            { event.probe_name }_{ event.clock } [
+                {{if event.is_known }}label        = \"{ event.meta.name }\"
+                description  = \"{ event.meta.description }\"
+                file         = \"{ event.meta.file }\"
+                probe        = \"{ event.probe_name }\"
+                tags         = \"{ event.meta.tags }\"{{ if event.has_payload }}
+                payload      = { event.payload }{{ endif }}
+                raw_event_id = { event.raw_id }
+                raw_probe_id = { event.raw_probe_id }{{ else }}
+                label        = \"UNKNOWN_EVENT_{ event.raw_id }\"
+                probe        = \"{ event.probe_name }\"
+                raw_event_id = { event.raw_id }
+                raw_probe_id = { event.raw_probe_id } {{ endif }}
+            ];
+            {{ endfor}}
         }
+        {{ endfor }}
     }
+    {{ endfor }}
 
-    impl Serialize for ComponentSet {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            let mut seq = serializer.serialize_seq(Some(self.0.values().len()))?;
-            for comp in self.0.values() {
-                seq.serialize_element(comp)?
-            }
-            seq.end()
-        }
-    }
+    {{ for edge in edges }}
+    { edge.from.probe_name }_{ edge.from.clock } -> { edge.to.probe_name }_{ edge.to.clock }
+    {{ endfor }}
+}";
 
-    impl Deref for ComponentSet {
-        type Target = HashMap<String, Component>;
-        fn deref(&self) -> &Self::Target {
-            &self.0
-        }
-    }
-
-    impl DerefMut for ComponentSet {
-        fn deref_mut(&mut self) -> &mut Self::Target {
-            &mut self.0
-        }
-    }
-
-    pub struct ProbeSet(HashMap<String, Probe>);
-
-    impl ProbeSet {
-        pub fn new() -> Self {
-            ProbeSet(HashMap::new())
-        }
-    }
-
-    impl Serialize for ProbeSet {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            let mut seq = serializer.serialize_seq(Some(self.0.values().len()))?;
-            for probe in self.0.values() {
-                seq.serialize_element(probe)?
-            }
-            seq.end()
-        }
-    }
-
-    impl Deref for ProbeSet {
-        type Target = HashMap<String, Probe>;
-        fn deref(&self) -> &Self::Target {
-            &self.0
-        }
-    }
-
-    impl DerefMut for ProbeSet {
-        fn deref_mut(&mut self) -> &mut Self::Target {
-            &mut self.0
-        }
-    }
-
-    pub struct EdgeSet(HashSet<Edge>);
-
-    impl EdgeSet {
-        pub fn new() -> Self {
-            EdgeSet(HashSet::new())
-        }
-    }
-
-    impl Deref for EdgeSet {
-        type Target = HashSet<Edge>;
-        fn deref(&self) -> &Self::Target {
-            &self.0
-        }
-    }
-
-    impl DerefMut for EdgeSet {
-        fn deref_mut(&mut self) -> &mut Self::Target {
-            &mut self.0
-        }
-    }
-
-    impl Serialize for EdgeSet {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
-            for edge in self.0.iter() {
-                seq.serialize_element(&edge)?
-            }
-            seq.end()
-        }
-    }
-
-    #[derive(Serialize)]
-    pub struct Context {
-        pub components: ComponentSet,
-        pub edges: EdgeSet,
-    }
-
-    #[derive(Serialize)]
-    pub struct Component {
-        pub cluster_idx: usize,
-        pub fill_color: String,
-        pub name: String,
-        pub probes: ProbeSet,
-    }
-
-    #[derive(Serialize)]
-    pub struct Probe {
-        pub cluster_idx: usize,
-        pub name: String,
-        pub raw_id: u32,
-        pub fill_color: String,
-        pub events: Vec<Event>,
-    }
-
-    #[derive(Hash, PartialEq, Eq, Serialize)]
-    pub struct Event {
-        pub is_known: bool,
-        pub meta: Option<EventMeta>,
-        pub has_payload: bool,
-        pub payload: Option<String>,
-        pub raw_id: u32,
-        pub raw_probe_id: u32,
-        pub probe_name: String,
-        pub seq: u64,
-        pub seq_idx: usize,
-    }
-
-    #[derive(PartialEq, Eq, Hash, Serialize)]
-    pub struct Edge {
-        pub from: Event,
-        pub to: Event,
-    }
-}
+pub const STATES: &'static str = "";
+pub const TOPO: &'static str = "";

--- a/modality-probe-cli/src/export/templates.rs
+++ b/modality-probe-cli/src/export/templates.rs
@@ -1,0 +1,204 @@
+pub mod complete {
+    use std::{
+        collections::{HashMap, HashSet},
+        ops::{Deref, DerefMut},
+    };
+
+    use serde::{
+        ser::{SerializeSeq, Serializer},
+        Serialize,
+    };
+
+    use crate::export::graph::EventMeta;
+
+    pub const TEMP: &'static str = "digraph G \\{
+    node [ color = \"#ffffff\" style = filled ]
+    edge [ color = \"#ffffff\" ]
+    {{ for comp in components }}
+    subgraph cluster_{ comp.cluster_idx } \\{
+        label = \"{ comp.name }\"
+        style = filled
+        color = \"{ comp.fill_color }\"
+        {{ for probe in comp.probes }}
+        subgraph cluster_{ probe.cluster_idx } \\{
+            label = \"{ probe.name }\"
+            fontcolor = \"#ffffff\"
+            rank = same
+            style = filled
+            color = \"{ probe.fill_color }\"
+            {{ for event in probe.events }}
+            {{ if event.is_known }}
+            { event.meta.name }_{ event.probe_name }_{ event.seq }_{ event.seq_idx } [
+                label        = \"{ event.meta.name }\"
+                description  = \"{ event.meta.description }\"
+                file         = \"{ event.meta.file }\"
+                probe        = \"{ event.probe_name }\"
+                tags         = \"{ event.meta.tags }\"{{ if event.has_payload }}
+                payload      = { event.payload }{{ endif }}
+                raw_event_id = { event.raw_id }
+                raw_probe_id = { event.raw_probe_id }
+            ];
+            {{ else }}
+            UNKNOWN_EVENT_{ event.probe_name }_{ event.seq }_{ event.seq_idx } [
+                label        = \"UNKNOWN_EVENT_{ event.raw_id }\"
+                probe        = \"{ event.probe_name }\"
+                raw_event_id = { event.raw_id }
+                raw_probe_id = { event.raw_probe_id }
+            ];
+            {{ endif }}
+            {{ endfor }}
+        }
+        {{ endfor }}
+    }
+    {{ endfor }}
+
+    {{ for edge in edges }}
+    {{ if edge.from.is_known }}{ edge.from.meta.name }{{ else }}UNKNOWN_EVENT_{ edge.from.raw_id }{{ endif }}_{ edge.from.probe_name }_{ edge.from.seq }_{ edge.from.seq_idx } ->
+    {{ if edge.to.is_known }}{ edge.to.meta.name }{{ else }}UNKNOWN_EVENT_{ edge.to.raw_id }{{ endif }}_{ edge.to.probe_name }_{ edge.to.seq }_{ edge.to.seq_idx };
+    {{ endfor }}
+}";
+
+    pub struct ComponentSet(HashMap<String, Component>);
+
+    impl ComponentSet {
+        pub fn new() -> Self {
+            ComponentSet(HashMap::new())
+        }
+    }
+
+    impl Serialize for ComponentSet {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let mut seq = serializer.serialize_seq(Some(self.0.values().len()))?;
+            for comp in self.0.values() {
+                seq.serialize_element(comp)?
+            }
+            seq.end()
+        }
+    }
+
+    impl Deref for ComponentSet {
+        type Target = HashMap<String, Component>;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl DerefMut for ComponentSet {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+
+    pub struct ProbeSet(HashMap<String, Probe>);
+
+    impl ProbeSet {
+        pub fn new() -> Self {
+            ProbeSet(HashMap::new())
+        }
+    }
+
+    impl Serialize for ProbeSet {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let mut seq = serializer.serialize_seq(Some(self.0.values().len()))?;
+            for probe in self.0.values() {
+                seq.serialize_element(probe)?
+            }
+            seq.end()
+        }
+    }
+
+    impl Deref for ProbeSet {
+        type Target = HashMap<String, Probe>;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl DerefMut for ProbeSet {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+
+    pub struct EdgeSet(HashSet<Edge>);
+
+    impl EdgeSet {
+        pub fn new() -> Self {
+            EdgeSet(HashSet::new())
+        }
+    }
+
+    impl Deref for EdgeSet {
+        type Target = HashSet<Edge>;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl DerefMut for EdgeSet {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+
+    impl Serialize for EdgeSet {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+            for edge in self.0.iter() {
+                seq.serialize_element(&edge)?
+            }
+            seq.end()
+        }
+    }
+
+    #[derive(Serialize)]
+    pub struct Context {
+        pub components: ComponentSet,
+        pub edges: EdgeSet,
+    }
+
+    #[derive(Serialize)]
+    pub struct Component {
+        pub cluster_idx: usize,
+        pub fill_color: String,
+        pub name: String,
+        pub probes: ProbeSet,
+    }
+
+    #[derive(Serialize)]
+    pub struct Probe {
+        pub cluster_idx: usize,
+        pub name: String,
+        pub raw_id: u32,
+        pub fill_color: String,
+        pub events: Vec<Event>,
+    }
+
+    #[derive(Hash, PartialEq, Eq, Serialize)]
+    pub struct Event {
+        pub is_known: bool,
+        pub meta: Option<EventMeta>,
+        pub has_payload: bool,
+        pub payload: Option<String>,
+        pub raw_id: u32,
+        pub raw_probe_id: u32,
+        pub probe_name: String,
+        pub seq: u64,
+        pub seq_idx: usize,
+    }
+
+    #[derive(PartialEq, Eq, Hash, Serialize)]
+    pub struct Edge {
+        pub from: Event,
+        pub to: Event,
+    }
+}

--- a/modality-probe-graph/src/lib.rs
+++ b/modality-probe-graph/src/lib.rs
@@ -18,8 +18,8 @@ pub trait Graph {
     fn add_edge(&mut self, source: GraphEvent, target: GraphEvent);
 }
 
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash)]
 /// A node in the event digraph.
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash)]
 pub struct GraphEvent {
     pub id: EventId,
     pub clock: LogicalClock,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,14 @@ pub struct LogicalClock {
     pub ticks: ProbeTicks,
 }
 
+impl LogicalClock {
+    /// Produce a tuple containing the probe id and a packed version
+    /// of the clock.
+    pub fn pack(&self) -> (ProbeId, u32) {
+        (self.id, pack_clock_word(self.epoch, self.ticks))
+    }
+}
+
 impl PartialOrd for LogicalClock {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         if self.id != other.id {


### PR DESCRIPTION
This also creates a pipeline so to speak for textual graph output by first converting the graph to a tree-like IR. This paves the way to output in languages other than Dot.

Closes #233.
Closes #237.
Closes #244.