### PR TITLE
cli: exclude internal events in graph output by default

### DIFF
--- a/modality-probe-cli/src/export/graph.rs
+++ b/modality-probe-cli/src/export/graph.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashSet, hash::Hash, iter::Peekable};
+use std::{
+    collections::{HashMap, HashSet},
+    hash::Hash,
+    iter::Peekable,
+};
 
 use serde::{Deserialize, Serialize};
 use tinytemplate::TinyTemplate;
@@ -70,10 +74,22 @@ where
 
 impl NodeAndEdgeLists<GraphEvent> {
     pub fn as_complete<'a>(&'a self, include_internals: bool) -> NodeAndEdgeLists<&'a GraphEvent> {
-        self.filter(
-            |n| include_internals || !n.id.is_internal(),
-            |s, t| include_internals || (!s.id.is_internal() && !t.id.is_internal()),
-        )
+        let nodes = self
+            .nodes
+            .iter()
+            .filter(|n| include_internals || !n.id.is_internal())
+            .collect();
+        let mut edges = HashSet::new();
+        for (s, t) in self.edges.iter() {
+            if !include_internals && t.id.is_internal() {
+                for (_, t2) in self.edges.iter().filter(|(s2, _)| s2 == t) {
+                    edges.insert((s, t2));
+                }
+            } else if include_internals || !s.id.is_internal() {
+                edges.insert((s, t));
+            }
+        }
+        NodeAndEdgeLists { nodes, edges }
     }
 
     /// Pare down a complete graph into only trace clocks, which is to
@@ -92,22 +108,28 @@ impl NodeAndEdgeLists<GraphEvent> {
 
     /// Pare down a complete graph into the event transitions.
     pub fn as_states<'a>(&'a self, include_internals: bool) -> NodeAndEdgeLists<&'a GraphEvent> {
-        let mut node_set = HashSet::new();
-        let mut edge_set = HashSet::new();
-        self.filter(
-            |n| {
-                (include_internals && node_set.insert((n.probe_id, n.id)))
-                    || (!include_internals
-                        && !n.id.is_internal()
-                        && node_set.insert((n.probe_id, n.id)))
-            },
-            |s, t| {
-                (include_internals && edge_set.insert(((s.probe_id, s.id), (t.probe_id, t.id))))
-                    || (!include_internals
-                        && !(s.id.is_internal() || t.id.is_internal())
-                        && edge_set.insert(((s.probe_id, s.id), (t.probe_id, t.id))))
-            },
-        )
+        let mut nodes = HashMap::new();
+        for n in self
+            .nodes
+            .iter()
+            .filter(|n| include_internals || !n.id.is_internal())
+        {
+            nodes.insert((n.probe_id, n.id), n);
+        }
+        let mut edges = HashMap::new();
+        for (s, t) in self.edges.iter() {
+            if !include_internals && t.id.is_internal() {
+                for (_, t2) in self.edges.iter().filter(|(s2, _)| s2 == t) {
+                    edges.insert(((s.probe_id, s.id), (t2.probe_id, t2.id)), (s, t2));
+                }
+            } else if include_internals || !s.id.is_internal() {
+                edges.insert(((s.probe_id, s.id), (t.probe_id, t.id)), (s, t));
+            }
+        }
+        NodeAndEdgeLists {
+            nodes: nodes.into_iter().map(|(_, v)| v).collect(),
+            edges: edges.into_iter().map(|(_, v)| v).collect(),
+        }
     }
 
     /// Pare down a complete graph into just the probes and their

--- a/modality-probe-cli/src/export/mod.rs
+++ b/modality-probe-cli/src/export/mod.rs
@@ -22,8 +22,11 @@ use graph::{EventMeta, ProbeMeta};
 pub struct Export {
     /// Generate the graph showing only the causal relationships,
     /// eliding the events in between.
-    #[structopt(short, long)]
+    #[structopt(long)]
     pub interactions_only: bool,
+    /// Include probe-generated events in the output.
+    #[structopt(long)]
+    pub include_internal_events: bool,
     /// The path to a component directory. To include multiple
     /// components, provide this switch multiple times.
     #[structopt(short, long, required = true)]
@@ -93,10 +96,11 @@ pub fn run(mut exp: Export) -> Result<(), ExportError> {
     match (exp.graph_type, exp.interactions_only) {
         (GraphType::Acyclic, false) => println!(
             "{}",
-            graph
-                .graph
-                .as_complete()
-                .dot(&cfg, "complete", templates::COMPLETE)?
+            graph.graph.as_complete(exp.include_internal_events).dot(
+                &cfg,
+                "complete",
+                templates::COMPLETE
+            )?
         ),
         (GraphType::Acyclic, true) => println!(
             "{}",
@@ -107,10 +111,11 @@ pub fn run(mut exp: Export) -> Result<(), ExportError> {
         ),
         (GraphType::Cyclic, false) => println!(
             "{}",
-            graph
-                .graph
-                .as_states()
-                .dot(&cfg, "states", templates::STATES)?
+            graph.graph.as_states(exp.include_internal_events).dot(
+                &cfg,
+                "states",
+                templates::STATES
+            )?
         ),
         (GraphType::Cyclic, true) => println!(
             "{}",

--- a/modality-probe-cli/src/opts.rs
+++ b/modality-probe-cli/src/opts.rs
@@ -132,6 +132,7 @@ mod test {
             ),
             Opts::Export(Export {
                 interactions_only: false,
+                include_internal_events: false,
                 components: vec![PathBuf::from("component")],
                 report: PathBuf::from("report.csv"),
                 graph_type: GraphType::Acyclic,
@@ -153,6 +154,7 @@ mod test {
             ),
             Opts::Export(Export {
                 interactions_only: true,
+                include_internal_events: false,
                 components: vec![PathBuf::from("component")],
                 report: PathBuf::from("report.csv"),
                 graph_type: GraphType::Cyclic,


### PR DESCRIPTION
This PR adds the `--include-internal-events` switch to the `export` sub-command. By default, these are now excluded.

---

Closes #235.