### PR TITLE
Dependencies cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [features]
 default = []
-std = ["serde", "proptest", "schemars", "proptest-derive"]
+std = ["serde", "proptest", "schemars"]
 debug-collector-access = ["field-offset"]
 
 [workspace]
@@ -40,8 +40,7 @@ fenced-ring-buffer = { path = "./fenced-ring-buffer" }
 
 # Used if the std feature is enabled.
 serde = { version = "1.0", features = ["derive"], optional = true }
-proptest = { version = "0.9.5", optional = true }
-proptest-derive = { version = "0.2.0", optional = true }
+proptest = { version = "0.9.5", optional = true , default-features = false, features = ["std"]}
 schemars = { version = "0.6.5", optional = true }
 
 # Used if the debug-collector-access feature is enabled

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ fenced-ring-buffer = { path = "./fenced-ring-buffer" }
 
 # Used if the std feature is enabled.
 serde = { version = "1.0", features = ["derive"], optional = true }
-proptest = { version = "0.9.5", optional = true , default-features = false, features = ["std"]}
+proptest = { version = "0.10.1", optional = true , default-features = false, features = ["std"]}
 schemars = { version = "0.6.5", optional = true }
 
 # Used if the debug-collector-access feature is enabled

--- a/collectors/modality-probe-collector-common/Cargo.toml
+++ b/collectors/modality-probe-collector-common/Cargo.toml
@@ -15,5 +15,5 @@ modality-probe = { path = "../../", features = ["std"] }
 fenced-ring-buffer = { path = "../../fenced-ring-buffer" }
 
 [dev-dependencies]
-proptest = "0.9"
+proptest = { version = "0.10.1", default-features = false, features = ["std"]}
 pretty_assertions = "0.6"

--- a/collectors/modality-probe-debug-collector/Cargo.toml
+++ b/collectors/modality-probe-debug-collector/Cargo.toml
@@ -22,7 +22,7 @@ goblin = "0.2.3"
 chrono = { version = "0.4", features = ["serde"] }
 structopt = "0.3"
 parse_duration = "2.1.0"
-probe-rs = "0.7.1"
+probe-rs = "0.8"
 maplit = "1.0.2"
 tempfile = "3.1.0"
 err-derive = "0.2.4"

--- a/collectors/modality-probe-udp-collector/Cargo.toml
+++ b/collectors/modality-probe-udp-collector/Cargo.toml
@@ -44,7 +44,7 @@ rust-lcm-codegen = "0.2.1"
 crossbeam = "0.7.3"
 lazy_static = "1.4.0"
 proc-graph = "0.1.0"
-proptest = "0.9"
+proptest = { version = "0.10.1", default-features = false, features = ["std"]}
 tempfile = "3"
 pretty_assertions = "0.6"
 modality-probe = { path = "../../" }

--- a/fenced-ring-buffer/Cargo.toml
+++ b/fenced-ring-buffer/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dev-dependencies]
 crossbeam = "0.7.3"
 rand = "0.7.3"
-proptest = "0.9.5"
+proptest = { version = "0.10.1", default-features = false, features = ["std"]}
 
 [features]
 default = []

--- a/modality-probe-capi/modality-probe-capi-impl/Cargo.toml
+++ b/modality-probe-capi/modality-probe-capi-impl/Cargo.toml
@@ -22,7 +22,7 @@ modality-probe = { path = "../../" }
 [build-dependencies]
 
 [dev-dependencies]
-proptest = "0.9.5"
+proptest = { version = "0.10.1", default-features = false, features = ["std"]}
 
 [features]
 default = []

--- a/modality-probe-cli/Cargo.toml
+++ b/modality-probe-cli/Cargo.toml
@@ -67,5 +67,5 @@ features = ["serde", "v4"]
 [dev-dependencies]
 pretty_assertions = "0.6"
 tempfile = "3.1"
-proptest = "0.9.5"
+proptest = { version = "0.10.1", default-features = false, features = ["std"]}
 modality-probe-graph = { path = "../modality-probe-graph", features = ["test_support"] }

--- a/src/id.rs
+++ b/src/id.rs
@@ -297,21 +297,13 @@ pub mod prop {
     /// binary search and clamps on valid _user_ values.
     pub struct EventIdBinarySearch(BinarySearch);
 
-    impl EventIdBinarySearch {
-        fn or_max(x: u32) -> EventId {
-            let x1 = x.checked_add(1).unwrap_or_else(|| EventId::MAX_USER_ID);
-            if x1 > EventId::MAX_USER_ID {
-                return EventId(unsafe { NonZeroU32::new_unchecked(EventId::MAX_USER_ID) });
-            }
-            EventId(unsafe { NonZeroU32::new_unchecked(x1) })
-        }
-    }
-
     impl ValueTree for EventIdBinarySearch {
         type Value = EventId;
 
         fn current(&self) -> EventId {
-            EventIdBinarySearch::or_max(self.0.current())
+            let x = self.0.current();
+            let x1 = core::cmp::max(1, core::cmp::min(x, EventId::MAX_USER_ID));
+            EventId(unsafe { NonZeroU32::new_unchecked(x1) })
         }
 
         fn simplify(&mut self) -> bool {
@@ -351,18 +343,13 @@ pub mod prop {
     /// binary search.
     pub struct ProbeIdBinarySearch(BinarySearch);
 
-    impl ProbeIdBinarySearch {
-        fn or_max(x: u32) -> ProbeId {
-            let x1: u32 = x.checked_add(1).unwrap_or_else(|| core::u32::MAX);
-            ProbeId(unsafe { NonZeroU32::new_unchecked(x1) })
-        }
-    }
-
     impl ValueTree for ProbeIdBinarySearch {
         type Value = ProbeId;
 
         fn current(&self) -> ProbeId {
-            ProbeIdBinarySearch::or_max(self.0.current())
+            let x = self.0.current();
+            let x1 = core::cmp::max(1, core::cmp::min(x, ProbeId::MAX_ID));
+            ProbeId(unsafe { NonZeroU32::new_unchecked(x1) })
         }
 
         fn simplify(&mut self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,14 +15,14 @@ use core::{
 
 use fixed_slice_vec::single::{embed, EmbedValueError, SplitUninitError};
 #[cfg(feature = "std")]
-use proptest::arbitrary::Arbitrary;
-#[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use static_assertions::{assert_cfg, const_assert};
 
 pub use error::*;
 use history::DynamicHistory;
 pub use id::*;
+#[cfg(feature = "std")]
+pub use prop::*;
 pub use restart_counter::{
     next_sequence_id_fn, CRestartCounterProvider, RestartCounter, RestartCounterProvider,
     RestartSequenceIdUnavailable, RustRestartCounterProvider,
@@ -518,6 +518,7 @@ impl<'a> Probe for ModalityProbe<'a> {
 #[cfg(feature = "std")]
 pub mod prop {
     use super::*;
+    use proptest::arbitrary::Arbitrary;
     use proptest::prelude::RngCore;
     use proptest::strategy::{NewTree, Strategy, ValueTree};
     use proptest::test_runner::TestRunner;


### PR DESCRIPTION
* Removes the `proptest_derive` dependency which was causing us to pull in a whole duplicate of the `syn`/`quote` proc-macro ecosystem
* Bump the proptest dependency, removing a duplicate of the `rand` ecosystem of dependencies
* Fixes our `Arbitrary` impl for ProbeId
* Bump the probe-rs dep to remove our last duplicate transitive dependency (which was on rusb)

This cleanup has been brought to you by the command `cargo tree --workspace -d` 