### PR TITLE
fix Rust toolchain link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ environments.
 
 ### Dependencies
 
-* [Rust Toolchain](https://rustup.sh)
+* [Rust Toolchain](https://rustup.rs)
 
 ### Building
 

--- a/collectors/modality-probe-debug-collector/README.md
+++ b/collectors/modality-probe-debug-collector/README.md
@@ -9,7 +9,7 @@ to the target program.
 
 ### Dependencies
 
-* [Rust Toolchain](https://rustup.sh)
+* [Rust Toolchain](https://rustup.rs)
 * [libusb](https://libusb.info/)
 * [libftd](https://www.intra2net.com/en/developer/libftdi/)
 

--- a/collectors/modality-probe-udp-collector/README.md
+++ b/collectors/modality-probe-udp-collector/README.md
@@ -12,7 +12,7 @@ reports into json lines and writes those lines to a file.
 
 ### Dependencies
 
-* [Rust Toolchain](https://rustup.sh)
+* [Rust Toolchain](https://rustup.rs)
 
 ### Building
 Once Rust is installed (don’t forget to follow directions about

--- a/modality-probe-capi/README.md
+++ b/modality-probe-capi/README.md
@@ -13,7 +13,7 @@ also targeted by the code and manifest generation that the CLI does.
 
 ### Dependencies
 
-* [Rust Toolchain](https://rustup.sh)
+* [Rust Toolchain](https://rustup.rs)
 
 ### Building
 Once Rust is installed, build the C API using Cargo:

--- a/modality-probe-cli/README.md
+++ b/modality-probe-cli/README.md
@@ -13,7 +13,7 @@ a collected trace as Graphviz dot code.
 
 ### Dependencies
 
-* [Rust Toolchain](https://rustup.sh)
+* [Rust Toolchain](https://rustup.rs)
 
 ### Building
 Once Rust is installed (don’t forget to follow directions about


### PR DESCRIPTION
Prior to this commit the README referenced `rustup.sh` as the canonical
host for installing Rust; however, the proper host is instead
`rustup.rs`, with the subsequent script using `sh.rustup.rs`. The commit
fixes the link for users following the modality-probe steps on a clean
system.