### PR TITLE
Increase the fixed-slice-vec version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ exclude = [
 
 [dependencies]
 static_assertions = "1.1.0"
-fixed-slice-vec = "0.4"
+fixed-slice-vec = "0.6"
 fenced-ring-buffer = { path = "./fenced-ring-buffer" }
 
 # Used if the std feature is enabled.

--- a/src/history.rs
+++ b/src/history.rs
@@ -7,7 +7,7 @@ use core::{
 
 use fixed_slice_vec::{
     single::{EmbedValueError, SplitUninitError},
-    FixedSliceVec, TryPushError,
+    FixedSliceVec, StorageError,
 };
 use static_assertions::{assert_eq_align, assert_eq_size, const_assert, const_assert_eq};
 
@@ -552,7 +552,7 @@ impl<'a> DynamicHistory<'a> {
     pub(crate) fn merge_clocks<'c>(
         clocks: &mut FixedSliceVec<'c, LogicalClock>,
         ext_clock: LogicalClock,
-    ) -> Result<(), TryPushError<LogicalClock>> {
+    ) -> Result<(), StorageError<LogicalClock>> {
         let mut existed = false;
         for c in clocks.iter_mut() {
             if c.id == ext_clock.id {


### PR DESCRIPTION
So that we can remove the older versions on crates.io that have a unsound behavior for a constructor for non-Copy types. Said constructor is not used in modality-probe.