### PR TITLE
Add missing debug collector reporting fields

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,13 +84,21 @@ jobs:
           cd examples/rust-example
           cargo clippy --all
 
+      - name: Test (armv7 target)
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          # Exclude debug collector because libusb is required to build
+          args: --all --exclude modality-probe-debug-collector --features "std, debug-collector-access" --target=armv7-unknown-linux-gnueabihf
+
       - name: Test (big endian target)
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: test
           # Exclude debug collector because libusb is required to build
-          args: --all --exclude modality-probe-debug-collector --features "std" --target=mips64-unknown-linux-gnuabi64
+          args: --all --exclude modality-probe-debug-collector --features "std, debug-collector-access" --target=mips64-unknown-linux-gnuabi64
 
   windows:
     name: Windows

--- a/modality-probe-cli/tests/export.rs
+++ b/modality-probe-cli/tests/export.rs
@@ -1,7 +1,11 @@
 #![deny(warnings)]
 
 #[test]
-#[cfg(all(target_os = "linux", target_endian = "little"))]
+#[cfg(all(
+    target_os = "linux",
+    target_endian = "little",
+    target_pointer_width = "64"
+))]
 fn visualize_cli_produces_a_reasonable_dot_file() {
     use std::{
         path::PathBuf,

--- a/modality-probe-cli/tests/test_helpers.rs
+++ b/modality-probe-cli/tests/test_helpers.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+#![deny(warnings, clippy::all)]
 
 use std::path::PathBuf;
 use std::process;

--- a/src/field_offsets.rs
+++ b/src/field_offsets.rs
@@ -19,6 +19,21 @@ pub fn probe_id_offset() -> u64 {
     offset_of!(DynamicHistory => probe_id).get_byte_offset() as u64
 }
 
+/// Offset of time_resolution field in DynamicHistory struct
+pub fn time_resolution_offset() -> u64 {
+    offset_of!(DynamicHistory => time_resolution).get_byte_offset() as u64
+}
+
+/// Offset of wall_clock_id field in DynamicHistory struct
+pub fn wall_clock_id_offset() -> u64 {
+    offset_of!(DynamicHistory => wall_clock_id).get_byte_offset() as u64
+}
+
+/// Offset of persistent_epoch_counting field in DynamicHistory struct
+pub fn persistent_epoch_counting_offset() -> u64 {
+    offset_of!(DynamicHistory => persistent_epoch_counting).get_byte_offset() as u64
+}
+
 /// Offset of the high word (u32) of the write sequence number field in DynamicHistory's FencedRingBuffer
 pub fn write_seqn_high_offset() -> u64 {
     offset_of!(DynamicHistory => log: FencedRingBuffer<LogEntry> => write_seqn: SeqNum => high)

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@
 set -ex
 
 cargo build --all
-cargo test --workspace --features "std"
+cargo test --workspace --features "std, debug-collector-access"
 cargo test --workspace
 
 (

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -309,7 +309,10 @@ fn report_missed_log_items() -> Result<(), ModalityProbeError> {
         let log_report = wire::WireReport::new(&report_dest[..bytes_written.get()]).unwrap();
 
         assert_eq!(log_report.n_clocks(), 1);
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(log_report.n_log_entries(), 80);
+        #[cfg(target_pointer_width = "32")]
+        assert_eq!(log_report.n_log_entries(), 88);
 
         let offset = log_report.n_clocks() as usize * mem::size_of::<LogicalClock>();
         let log_bytes = &log_report.payload()[offset..];
@@ -326,9 +329,15 @@ fn report_missed_log_items() -> Result<(), ModalityProbeError> {
         );
 
         if i == 0 {
+            #[cfg(target_pointer_width = "64")]
             assert_eq!(raw_payload, 949);
+            #[cfg(target_pointer_width = "32")]
+            assert_eq!(raw_payload, 941);
         } else {
+            #[cfg(target_pointer_width = "64")]
             assert_eq!(raw_payload, 947);
+            #[cfg(target_pointer_width = "32")]
+            assert_eq!(raw_payload, 939);
         }
     }
 


### PR DESCRIPTION
* Adds access to additional probe state: persistent_epoch_counting, time_resolution, wall_clock_id
* Run the tests in CI using a 32-bit armv7 target, previously was only building the crates

Based on #285