### PR TITLE
Bump fsv, piping through the changes in required MaybeUninit bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ exclude = [
 
 [dependencies]
 static_assertions = "1.1.0"
-fixed-slice-vec = "0.6"
+fixed-slice-vec = "0.7.1"
 fenced-ring-buffer = { path = "./fenced-ring-buffer" }
 
 # Used if the std feature is enabled.

--- a/collectors/modality-probe-collector-common/src/lib.rs
+++ b/collectors/modality-probe-collector-common/src/lib.rs
@@ -819,6 +819,7 @@ pub(crate) mod test {
     use proptest::prelude::*;
     use proptest::std_facade::*;
     use std::convert::TryFrom;
+    use std::mem::MaybeUninit;
 
     pub fn arb_session_id() -> impl Strategy<Value = SessionId> {
         any::<u32>().prop_map_into()
@@ -978,7 +979,7 @@ pub(crate) mod test {
 
     #[test]
     fn report_e2e() {
-        let mut storage1 = vec![0; 1024];
+        let mut storage1 = vec![MaybeUninit::new(0); 1024];
         let mut p1 = modality_probe::ModalityProbe::new_with_storage(
             &mut storage1,
             ProbeId::new(1).unwrap(),
@@ -986,7 +987,7 @@ pub(crate) mod test {
         )
         .unwrap();
 
-        let mut storage2 = vec![0; 1024];
+        let mut storage2 = vec![MaybeUninit::new(0); 1024];
         let mut p2 = modality_probe::ModalityProbe::new_with_storage(
             &mut storage2,
             ProbeId::new(2).unwrap(),

--- a/collectors/modality-probe-debug-collector/src/lib.rs
+++ b/collectors/modality-probe-debug-collector/src/lib.rs
@@ -549,6 +549,7 @@ pub mod tests {
 
     use modality_probe::{EventId, ModalityProbe, Probe, RestartCounterProvider};
     use modality_probe_collector_common::{EventLogEntry, SequenceNumber};
+    use std::mem::MaybeUninit;
 
     fn lc(probe_id: u32, epoch: u16, ticks: u16) -> LogicalClock {
         LogicalClock {
@@ -631,7 +632,7 @@ pub mod tests {
 
     #[test]
     fn local_probe() {
-        let mut storage = [0u8; 1024];
+        let mut storage = [MaybeUninit::new(0u8); 1024];
         let pid_raw = 1;
         let probe_id = ProbeId::new(pid_raw).unwrap();
         let mut probe = ModalityProbe::new_with_storage(
@@ -674,7 +675,7 @@ pub mod tests {
 
     #[test]
     fn local_misaligned() {
-        let mut storage = [0u8; 1024];
+        let mut storage = [MaybeUninit::new(0u8); 1024];
         let offset = 1 + storage.as_ptr().align_offset(align_of::<ModalityProbe>());
         let storage_unaligned = &mut storage[offset..];
         let storage_unaligned_ptr = storage_unaligned.as_ptr();
@@ -690,7 +691,7 @@ pub mod tests {
         let padding_len = (align_of::<ModalityProbe>() - 1) as isize;
         for i in 0..padding_len {
             assert_eq!(
-                unsafe { *(storage_unaligned_ptr.offset(i as isize)) },
+                unsafe { (*(storage_unaligned_ptr.offset(i as isize))).assume_init() },
                 ModalityProbe::PADDING_GUARD_BYTE
             );
         }
@@ -733,7 +734,7 @@ pub mod tests {
 
     #[test]
     fn local_invalid_address() {
-        let mut storage = [0u8; 1024];
+        let mut storage = [MaybeUninit::new(0u8); 1024];
         let pid_raw = 1;
         let probe_id = ProbeId::new(pid_raw).unwrap();
         let probe = ModalityProbe::new_with_storage(
@@ -763,7 +764,7 @@ pub mod tests {
 
     #[test]
     fn local_invalid_ptr() {
-        let mut storage = [0u8; 1024];
+        let mut storage = [MaybeUninit::new(0u8); 1024];
         let pid_raw = 1;
         let probe_id = ProbeId::new(pid_raw).unwrap();
         let probe = ModalityProbe::new_with_storage(
@@ -794,7 +795,7 @@ pub mod tests {
 
     #[test]
     fn local_probe_interaction() {
-        let mut storage = [0u8; 1024];
+        let mut storage = [MaybeUninit::new(0u8); 1024];
         let pid_raw = 1;
         let probe_id = ProbeId::new(pid_raw).unwrap();
         let mut probe = ModalityProbe::new_with_storage(
@@ -805,7 +806,7 @@ pub mod tests {
         .unwrap();
         let addr_raw = &probe as *const ModalityProbe as usize;
 
-        let mut storage_2 = [0u8; 1024];
+        let mut storage_2 = [MaybeUninit::new(0u8); 1024];
         let pid_raw_2 = 2;
         let probe_id_2 = ProbeId::new(pid_raw_2).unwrap();
         let mut probe_2 = ModalityProbe::new_with_storage(
@@ -921,7 +922,7 @@ pub mod tests {
 
     #[test]
     fn local_probe_writeback() {
-        let mut storage = [0u8; 1024];
+        let mut storage = [MaybeUninit::new(0u8); 1024];
         let pid_raw = 1;
         let probe_id = ProbeId::new(pid_raw).unwrap();
         let probe = ModalityProbe::new_with_storage(

--- a/collectors/modality-probe-offline-batch-collector/tests/integration_tests.rs
+++ b/collectors/modality-probe-offline-batch-collector/tests/integration_tests.rs
@@ -7,6 +7,7 @@ use proptest::prelude::*;
 use std::convert::TryInto;
 use std::fs::File;
 use std::io::Write;
+use std::mem::MaybeUninit;
 
 const STORAGE_SIZE: usize = 512;
 
@@ -82,7 +83,7 @@ proptest! {
         init_logging();
 
         let probe_id_a = 1.try_into().unwrap();
-        let mut storage_a = vec![0_u8; STORAGE_SIZE];
+        let mut storage_a = vec![MaybeUninit::new(0_u8); STORAGE_SIZE];
         let probe_a = ModalityProbe::initialize_at(
             &mut storage_a,
             probe_id_a,
@@ -91,7 +92,7 @@ proptest! {
         .unwrap();
 
         let probe_id_b = 2.try_into().unwrap();
-        let mut storage_b = vec![0_u8; STORAGE_SIZE];
+        let mut storage_b = vec![MaybeUninit::new(0_u8); STORAGE_SIZE];
         let probe_b = ModalityProbe::initialize_at(
             &mut storage_b,
             probe_id_b,
@@ -100,7 +101,7 @@ proptest! {
         .unwrap();
 
         let probe_id_c = 3.try_into().unwrap();
-        let mut storage_c = vec![0_u8; STORAGE_SIZE];
+        let mut storage_c = vec![MaybeUninit::new(0_u8); STORAGE_SIZE];
         let probe_c = ModalityProbe::initialize_at(
             &mut storage_c,
             probe_id_c,
@@ -201,7 +202,7 @@ fn missed_reports_are_detected() {
     init_logging();
 
     let probe_id = 1.try_into().unwrap();
-    let mut storage = vec![0_u8; STORAGE_SIZE];
+    let mut storage = vec![MaybeUninit::new(0u8); STORAGE_SIZE];
     let probe = ModalityProbe::initialize_at(
         &mut storage,
         probe_id,
@@ -271,7 +272,7 @@ fn discarded_reports_are_detected() {
     init_logging();
 
     let probe_id = 1.try_into().unwrap();
-    let mut storage = vec![0_u8; STORAGE_SIZE];
+    let mut storage = vec![MaybeUninit::new(0_u8); STORAGE_SIZE];
     let probe = ModalityProbe::initialize_at(
         &mut storage,
         probe_id,

--- a/collectors/modality-probe-udp-collector/src/lib.rs
+++ b/collectors/modality-probe-udp-collector/src/lib.rs
@@ -176,6 +176,7 @@ mod tests {
     use modality_probe_collector_common::*;
 
     use super::*;
+    use std::mem::MaybeUninit;
 
     fn dummy_report(raw_main_probe_id: u32) -> Report {
         Report {
@@ -805,7 +806,7 @@ mod tests {
     ) + Send
            + 'static {
         move |id_to_sender, _receiver| {
-            let mut probe_storage = vec![0u8; PROBE_STORAGE_BYTES_SIZE];
+            let mut probe_storage = vec![MaybeUninit::new(0u8); PROBE_STORAGE_BYTES_SIZE];
             let mut probe = modality_probe::ModalityProbe::new_with_storage(
                 &mut probe_storage,
                 probe_id,
@@ -868,7 +869,7 @@ mod tests {
     ) + Send
            + 'static {
         move |id_to_sender, receiver| {
-            let mut probe_storage = vec![0u8; PROBE_STORAGE_BYTES_SIZE];
+            let mut probe_storage = vec![MaybeUninit::new(0u8); PROBE_STORAGE_BYTES_SIZE];
             let mut probe = modality_probe::ModalityProbe::new_with_storage(
                 &mut probe_storage,
                 probe_id,
@@ -949,7 +950,7 @@ mod tests {
     ) + Send
            + 'static {
         move |_id_to_sender, receiver| {
-            let mut probe_storage = vec![0u8; PROBE_STORAGE_BYTES_SIZE];
+            let mut probe_storage = vec![MaybeUninit::new(0u8); PROBE_STORAGE_BYTES_SIZE];
             let mut probe = modality_probe::ModalityProbe::new_with_storage(
                 &mut probe_storage,
                 probe_id,

--- a/examples/rust-example/src/main.rs
+++ b/examples/rust-example/src/main.rs
@@ -61,7 +61,7 @@ impl fmt::Display for Measurement {
 fn measurement_producer_thread(tx: crossbeam_channel::Sender<Measurement>) {
     info!("Sensor measurement producer thread starting");
 
-    let mut storage = [0u8; PROBE_SIZE];
+    let mut storage = [std::mem::MaybeUninit::new(0u8); PROBE_SIZE];
     let probe = initialize_at!(
         &mut storage,
         PRODUCER_PROBE,
@@ -121,7 +121,7 @@ fn measurement_producer_thread(tx: crossbeam_channel::Sender<Measurement>) {
 fn measurement_consumer_thread(rx: crossbeam_channel::Receiver<Measurement>) {
     info!("Sensor measurement consumer thread starting");
 
-    let mut storage = [0u8; PROBE_SIZE];
+    let mut storage = [std::mem::MaybeUninit::new(0u8); PROBE_SIZE];
     let probe = initialize_at!(
         &mut storage,
         CONSUMER_PROBE,

--- a/fenced-ring-buffer/src/buffer.rs
+++ b/fenced-ring-buffer/src/buffer.rs
@@ -91,6 +91,7 @@ where
     /// Create new FencedRingBuffer with properly aligned backing storage,
     /// return unused bytes
     #[inline]
+    #[allow(clippy::type_complexity)]
     pub fn align_from_uninit_bytes(
         bytes: &'a mut [MaybeUninit<u8>],
         use_base_2_indexing: bool,

--- a/fenced-ring-buffer/src/buffer.rs
+++ b/fenced-ring-buffer/src/buffer.rs
@@ -80,24 +80,24 @@ where
 
     /// Create new FencedRingBuffer with properly aligned backing storage
     #[inline]
-    pub fn new_from_bytes(
-        bytes: &'a mut [u8],
+    pub fn new_from_uninit_bytes(
+        bytes: &'a mut [MaybeUninit<u8>],
         use_base_2_indexing: bool,
     ) -> Result<FencedRingBuffer<'a, E>, SizeError> {
-        let (_prefix, buf, _suffix) = Self::align_from_bytes(bytes, use_base_2_indexing);
+        let (_prefix, buf, _suffix) = Self::align_from_uninit_bytes(bytes, use_base_2_indexing);
         buf
     }
 
     /// Create new FencedRingBuffer with properly aligned backing storage,
     /// return unused bytes
     #[inline]
-    pub fn align_from_bytes(
-        bytes: &'a mut [u8],
+    pub fn align_from_uninit_bytes(
+        bytes: &'a mut [MaybeUninit<u8>],
         use_base_2_indexing: bool,
     ) -> (
-        &'a mut [u8],
+        &'a mut [MaybeUninit<u8>],
         Result<FencedRingBuffer<'a, E>, SizeError>,
-        &'a mut [u8],
+        &'a mut [MaybeUninit<u8>],
     ) {
         // Safe because storage is treated as uninit after transmutation
         let (prefix, storage, suffix) = unsafe { bytes.align_to_mut() };
@@ -451,9 +451,9 @@ mod tests {
     proptest! {
         #[test]
         fn test_from_bytes(storage_cap in MIN_STORAGE_CAP..=7777) {
-            let mut storage = vec![0u8; storage_cap * size_of::<OrderedEntry>()];
+            let mut storage = vec![MaybeUninit::new(0u8); storage_cap * size_of::<OrderedEntry>()];
             let buf =
-                FencedRingBuffer::<OrderedEntry>::new_from_bytes(&mut storage[..], false).unwrap();
+                FencedRingBuffer::<OrderedEntry>::new_from_uninit_bytes(&mut storage[..], false).unwrap();
             // Should not lose more than one entry
             prop_assert!(buf.capacity() == storage_cap || (buf.capacity() == storage_cap - 1))
         }

--- a/modality-probe-capi/modality-probe-capi-impl/src/lib.rs
+++ b/modality-probe-capi/modality-probe-capi-impl/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+use core::mem::MaybeUninit;
 use modality_probe::*;
 pub use modality_probe::{
     next_sequence_id_fn, CausalSnapshot, ModalityProbe, ModalityProbeInstant,
@@ -50,7 +51,7 @@ pub const MODALITY_PROBE_ERROR_RESTART_PERSISTENCE_SEQUENCE_ID_UNAVAILABLE: Moda
 /// in the case of an error.
 #[cfg_attr(feature = "no_mangle", no_mangle)]
 pub unsafe fn modality_probe_initialize(
-    destination: *mut u8,
+    destination: *mut MaybeUninit<u8>,
     destination_size_bytes: usize,
     probe_id: u32,
     next_sequence_id: Option<next_sequence_id_fn>,
@@ -360,12 +361,12 @@ mod tests {
         let mut backend = [0u8; 2099];
 
         let probe_id = 2;
-        let mut storage = [0u8; 1024];
+        let mut storage = [MaybeUninit::new(0u8); 1024];
         let storage_slice = &mut storage;
         let mut probe = MaybeUninit::uninit();
         let result = unsafe {
             modality_probe_initialize(
-                storage_slice.as_mut_ptr() as *mut u8,
+                storage_slice.as_mut_ptr(),
                 storage_slice.len(),
                 probe_id,
                 None,
@@ -425,12 +426,12 @@ mod tests {
         // some other thread.
         let remote_probe_id = probe_id + 1;
 
-        let mut remote_storage = [0u8; 1024];
+        let mut remote_storage = [MaybeUninit::new(0u8); 1024];
         let remote_storage_slice = &mut remote_storage;
         let mut remote_probe = MaybeUninit::uninit();
         let result = unsafe {
             modality_probe_initialize(
-                remote_storage_slice.as_mut_ptr() as *mut u8,
+                remote_storage_slice.as_mut_ptr(),
                 remote_storage_slice.len(),
                 remote_probe_id,
                 None,

--- a/modality-probe-capi/modality-probe-capi-impl/tests/integration_tests.rs
+++ b/modality-probe-capi/modality-probe-capi-impl/tests/integration_tests.rs
@@ -26,10 +26,10 @@ fn initialization_errors() {
 
     {
         let mut probe = MaybeUninit::uninit();
-        let mut storage = [0u8; 512];
+        let mut storage = [MaybeUninit::new(0u8); 512];
         let err = unsafe {
             modality_probe_initialize(
-                storage.as_mut_ptr() as *mut u8,
+                storage.as_mut_ptr(),
                 0, // Zero storage size
                 probe_id,
                 None,
@@ -41,10 +41,10 @@ fn initialization_errors() {
     }
 
     {
-        let mut storage = [0u8; 512];
+        let mut storage = [MaybeUninit::new(0u8); 512];
         let err = unsafe {
             modality_probe_initialize(
-                storage.as_mut_ptr() as *mut u8,
+                storage.as_mut_ptr(),
                 storage.len(),
                 probe_id,
                 None,
@@ -66,10 +66,10 @@ fn event_recording_errors() {
 
     let probe_id = 1;
     let mut probe = MaybeUninit::uninit();
-    let mut storage = [0u8; 512];
+    let mut storage = [MaybeUninit::new(0u8); 512];
     let err = unsafe {
         modality_probe_initialize(
-            storage.as_mut_ptr() as *mut u8,
+            storage.as_mut_ptr(),
             storage.len(),
             probe_id,
             None,
@@ -107,10 +107,10 @@ fn reporting_errors() {
 
     let probe_id = 1;
     let mut probe = MaybeUninit::uninit();
-    let mut storage = [0u8; 512];
+    let mut storage = [MaybeUninit::new(0u8); 512];
     let err = unsafe {
         modality_probe_initialize(
-            storage.as_mut_ptr() as *mut u8,
+            storage.as_mut_ptr(),
             storage.len(),
             probe_id,
             None,
@@ -196,10 +196,10 @@ fn produce_snapshot_errors() {
 
     let probe_id = 1;
     let mut probe = MaybeUninit::uninit();
-    let mut storage = [0u8; 512];
+    let mut storage = [MaybeUninit::new(0u8); 512];
     let err = unsafe {
         modality_probe_initialize(
-            storage.as_mut_ptr() as *mut u8,
+            storage.as_mut_ptr(),
             storage.len(),
             probe_id,
             None,
@@ -281,10 +281,10 @@ fn merge_snapshot_errors() {
 
     let probe_id = 1;
     let mut probe = MaybeUninit::uninit();
-    let mut storage = [0u8; 512];
+    let mut storage = [MaybeUninit::new(0u8); 512];
     let err = unsafe {
         modality_probe_initialize(
-            storage.as_mut_ptr() as *mut u8,
+            storage.as_mut_ptr(),
             storage.len(),
             probe_id,
             None,
@@ -344,12 +344,12 @@ proptest! {
         prop_assert!(report_buffer.len() <= report_buffer.len());
 
         let probe_id = 1;
-        let mut storage = [0u8; 1024];
+        let mut storage = [MaybeUninit::new(0u8); 1024];
         let storage_slice = &mut storage;
         let mut probe = MaybeUninit::uninit();
         let err = unsafe {
             modality_probe_initialize(
-                storage_slice.as_mut_ptr() as *mut u8,
+                storage_slice.as_mut_ptr(),
                 storage_slice.len(),
                 probe_id,
                 None,
@@ -396,11 +396,11 @@ proptest! {
     #[test]
     fn snapshot_exchanges_advance_clock(num_snapshot_exchanges in 1_usize..=1024_usize) {
         let probe_id_foo = 1;
-        let mut storage_foo = [0u8; 512];
+        let mut storage_foo = [MaybeUninit::new(0u8); 512];
         let mut probe_foo = MaybeUninit::uninit();
         let err = unsafe {
             modality_probe_initialize(
-                storage_foo.as_mut_ptr() as *mut u8,
+                storage_foo.as_mut_ptr(),
                 storage_foo.len(),
                 probe_id_foo,
                 None,
@@ -412,11 +412,11 @@ proptest! {
         let probe_foo = unsafe { probe_foo.assume_init() };
 
         let probe_id_bar = 2;
-        let mut storage_bar = [0u8; 512];
+        let mut storage_bar = [MaybeUninit::new(0u8); 512];
         let mut probe_bar = MaybeUninit::uninit();
         let err = unsafe {
             modality_probe_initialize(
-                storage_bar.as_mut_ptr() as *mut u8,
+                storage_bar.as_mut_ptr(),
                 storage_bar.len(),
                 probe_id_bar,
                 None,

--- a/modality-probe-capi/src/lib.rs
+++ b/modality-probe-capi/src/lib.rs
@@ -1,13 +1,14 @@
 #![no_std]
 #![feature(lang_items, core_intrinsics)]
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
+use core::mem::MaybeUninit;
 pub use modality_probe_capi_impl::{
     next_sequence_id_fn, CausalSnapshot, ModalityProbe, ModalityProbeError, ModalityProbeInstant,
 };
 
 #[no_mangle]
 pub extern "C" fn modality_probe_initialize(
-    destination: *mut u8,
+    destination: *mut MaybeUninit<u8>,
     destination_size_bytes: usize,
     probe_id: u32,
     next_sequence_id: Option<next_sequence_id_fn>,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -493,11 +493,12 @@ macro_rules! __payload_as_u32_impls {
 #[cfg(test)]
 mod tests {
     use crate::{EventId, ModalityProbe, Probe, ProbeId, RestartCounterProvider};
+    use core::mem::MaybeUninit;
 
     #[test]
     fn event_macro_use() {
         let probe_id = ProbeId::new(1).unwrap();
-        let mut storage = [0_u8; 1024];
+        let mut storage = [MaybeUninit::new(0_u8); 1024];
         let probe = ModalityProbe::initialize_at(
             &mut storage,
             probe_id,
@@ -586,7 +587,7 @@ mod tests {
     #[test]
     fn probe_macro_use() {
         let probe_id = ProbeId::new(1).unwrap();
-        let mut storage = [0_u8; 1024];
+        let mut storage = [MaybeUninit::new(0_u8); 1024];
         let _probe = initialize_at!(
             &mut storage,
             probe_id,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,6 +1,7 @@
 #![deny(warnings)]
 
 use core::mem;
+use core::mem::MaybeUninit;
 use modality_probe::*;
 use proptest::prelude::*;
 use std::convert::{TryFrom, TryInto};
@@ -25,7 +26,7 @@ fn probe_lifecycle_does_not_panic() -> Result<(), ModalityProbeError> {
     let probe_id = 1u32.try_into()?;
 
     let mut backend = Buffer::new(1024);
-    let mut storage = [0u8; 1024];
+    let mut storage = [MaybeUninit::new(0u8); 1024];
     let probe = ModalityProbe::initialize_at(
         &mut storage,
         probe_id,
@@ -63,7 +64,7 @@ fn round_trip_merge_snapshot() -> Result<(), ModalityProbeError> {
     let probe_id_foo = 1.try_into()?;
     let probe_id_bar = 2.try_into()?;
 
-    let mut storage_foo = [0u8; 1024];
+    let mut storage_foo = [MaybeUninit::new(0u8); 1024];
     let probe_foo = ModalityProbe::initialize_at(
         &mut storage_foo,
         probe_id_foo,
@@ -72,7 +73,7 @@ fn round_trip_merge_snapshot() -> Result<(), ModalityProbeError> {
     let snap_foo_a = probe_foo.produce_snapshot();
 
     // Re-initialize a probe with no previous history
-    let mut storage_bar = [0u8; 1024];
+    let mut storage_bar = [MaybeUninit::new(0u8); 1024];
     let probe_bar = ModalityProbe::initialize_at(
         &mut storage_bar,
         probe_id_bar,
@@ -96,7 +97,7 @@ fn round_trip_merge_snapshot() -> Result<(), ModalityProbeError> {
 
 #[test]
 fn happy_path_backend_service() -> Result<(), ModalityProbeError> {
-    let mut storage_foo = [0u8; 1024];
+    let mut storage_foo = [MaybeUninit::new(0u8); 1024];
     let probe_id_foo = 123.try_into()?;
     let mut probe = ModalityProbe::new_with_storage(
         &mut storage_foo,
@@ -186,7 +187,7 @@ fn all_allowed_events() -> Result<(), ModalityProbeError> {
 
 #[test]
 fn try_initialize_handles_raw_probe_ids() {
-    let mut storage = [0u8; 512];
+    let mut storage = [MaybeUninit::new(0u8); 512];
     assert!(ModalityProbe::try_initialize_at(
         &mut storage,
         0,
@@ -209,7 +210,7 @@ fn try_initialize_handles_raw_probe_ids() {
 
 #[test]
 fn try_record_event_raw_probe_ids() -> Result<(), ModalityProbeError> {
-    let mut storage = [0u8; 512];
+    let mut storage = [MaybeUninit::new(0u8); 512];
     let probe = ModalityProbe::try_initialize_at(
         &mut storage,
         1,
@@ -229,7 +230,7 @@ fn try_record_event_raw_probe_ids() -> Result<(), ModalityProbeError> {
 
 #[test]
 fn report_buffer_too_small_error() -> Result<(), ModalityProbeError> {
-    let mut storage = [0u8; 512];
+    let mut storage = [MaybeUninit::new(0u8); 512];
     let probe = ModalityProbe::try_initialize_at(
         &mut storage,
         1,
@@ -269,7 +270,7 @@ fn report_buffer_too_small_error() -> Result<(), ModalityProbeError> {
 #[test]
 fn report_missed_log_items() -> Result<(), ModalityProbeError> {
     const NUM_STORAGE_BYTES: usize = 512;
-    let mut storage = [0u8; NUM_STORAGE_BYTES];
+    let mut storage = [MaybeUninit::new(0u8); NUM_STORAGE_BYTES];
     let probe = ModalityProbe::try_initialize_at(
         &mut storage,
         1,
@@ -325,7 +326,7 @@ proptest! {
         // num_events and num_events_with_payload set to at least 1
         // so that we can have a total of at least 2 events
 
-        let mut storage = [0u8; 512];
+        let mut storage = [MaybeUninit::new(0u8); 512];
         let probe = ModalityProbe::try_initialize_at(
             &mut storage,
             1,
@@ -408,7 +409,7 @@ fn persistent_restart_sequence_id() -> Result<(), ModalityProbeError> {
         });
 
         let probe_id = 1u32.try_into()?;
-        let mut storage = [0u8; 1024];
+        let mut storage = [MaybeUninit::new(0u8); 1024];
         let probe = ModalityProbe::initialize_at(&mut storage, probe_id, provider)?;
 
         let now = probe.now();
@@ -429,7 +430,7 @@ fn persistent_restart_sequence_id() -> Result<(), ModalityProbeError> {
         });
 
         let probe_id = 1u32.try_into()?;
-        let mut storage = [0u8; 1024];
+        let mut storage = [MaybeUninit::new(0u8); 1024];
         let probe = ModalityProbe::initialize_at(&mut storage, probe_id, provider)?;
 
         let now = probe.now();


### PR DESCRIPTION
Correctly identify the fact that the opaque bytes provided to modality-probe should truly be opaque.