### PR TITLE
Make ProbeId a composite of InstanceId and GeneratedId

### DIFF
--- a/modality-probe-capi/include/probe.h
+++ b/modality-probe-capi/include/probe.h
@@ -109,6 +109,25 @@ typedef size_t (*modality_probe_next_sequence_id_fn)(
         void *user_state,
         uint16_t *out_sequence_id);
 
+/*
+ * Initialize a new InstanceId generator.
+ */
+#define MODALITY_PROBE_INSTANCE_ID_GEN_INIT (0)
+
+/*
+ * Thread-safe Modality probe InstanceId generator, values start at zero and stop at InstanceId::MAX_ID.
+ *
+ * Use `MODALITY_PROBE_INSTANCE_ID_GEN_INIT` or `modality_probe_instance_id_gen_initialize()` to initialize.
+ */
+typedef size_t modality_probe_instance_id_gen;
+
+/*
+ * Modality probe InstanceId.
+ * Part of the ProbeId, a 6-bit runtime identifier user-supplied at probe initialization
+ * used to indicate a particular instance of a probe.
+ */
+typedef size_t modality_probe_instance_id;
+
 typedef enum {
     /*
      * Everything is okay
@@ -162,6 +181,10 @@ typedef enum {
      * A wall clock time outside of the allowed range was provided.
      */
     MODALITY_PROBE_ERROR_INVALID_WALL_CLOCK_TIME = 10,
+    /*
+     * The instance id generator reached the maximum number of instance ids available.
+     */
+    MODALITY_PROBE_ERROR_EXCEEDED_MAXIMUM_INSTANCE_IDS = 11,
 } modality_probe_error;
 
 /*
@@ -703,6 +726,19 @@ size_t modality_probe_merge_snapshot_bytes_with_time(
  */
 modality_probe_instant modality_probe_now(
         modality_probe *probe);
+
+/*
+ * Initialize an InstanceIdGen, the generated values start at zero and stop at InstanceId::MAX_ID.
+ */
+size_t modality_probe_instance_id_gen_initialize(
+        modality_probe_instance_id_gen *gen);
+
+/*
+ * Get the next available InstanceId.
+ */
+size_t modality_probe_instance_id_gen_next(
+        modality_probe_instance_id_gen *gen,
+        modality_probe_instance_id *instance_id);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/modality-probe-capi/src/lib.rs
+++ b/modality-probe-capi/src/lib.rs
@@ -3,7 +3,8 @@
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 use core::mem::MaybeUninit;
 pub use modality_probe_capi_impl::{
-    next_sequence_id_fn, CausalSnapshot, ModalityProbe, ModalityProbeError, ModalityProbeInstant,
+    next_sequence_id_fn, CausalSnapshot, InstanceIdGen, ModalityProbe, ModalityProbeError,
+    ModalityProbeInstant,
 };
 
 #[no_mangle]
@@ -464,6 +465,21 @@ pub extern "C" fn modality_probe_merge_snapshot_bytes_with_time(
 #[no_mangle]
 pub extern "C" fn modality_probe_now(probe: *mut ModalityProbe<'static>) -> ModalityProbeInstant {
     unsafe { modality_probe_capi_impl::modality_probe_now(probe) }
+}
+
+#[no_mangle]
+pub extern "C" fn modality_probe_instance_id_gen_initialize(
+    gen: *mut InstanceIdGen,
+) -> ModalityProbeError {
+    unsafe { modality_probe_capi_impl::modality_probe_instance_id_gen_initialize(gen) }
+}
+
+#[no_mangle]
+pub extern "C" fn modality_probe_instance_id_gen_next(
+    gen: *mut InstanceIdGen,
+    instance_id: *mut usize,
+) -> ModalityProbeError {
+    unsafe { modality_probe_capi_impl::modality_probe_instance_id_gen_next(gen, instance_id) }
 }
 
 #[cfg(not(test))]

--- a/modality-probe-cli/src/manifest_gen/invocations.rs
+++ b/modality-probe-cli/src/manifest_gen/invocations.rs
@@ -498,12 +498,12 @@ impl Invocations {
         loop {
             let next_id = gen.hashed_id(probe_name);
 
-            let id_already_taken = existing_probe_ids.iter().any(|&id| id == next_id.get());
-            let is_valid_probe_id = modality_probe::ProbeId::new(next_id.get()).is_some();
+            let id_already_taken = existing_probe_ids.iter().any(|&id| id == next_id.get_raw());
+            let is_valid_probe_id = modality_probe::ProbeId::new(next_id.get_raw()).is_some();
 
             if !id_already_taken && is_valid_probe_id {
-                existing_probe_ids.push(next_id.get());
-                return ProbeId(next_id.get());
+                existing_probe_ids.push(next_id.get_raw());
+                return ProbeId(next_id.get_raw());
             }
 
             // Escape hatch
@@ -777,7 +777,7 @@ mod tests {
         };
         let probe_id_range = NonZeroIdRange::new(
             NonZeroU32::new(1).unwrap(),
-            NonZeroU32::new(modality_probe::ProbeId::MAX_ID).unwrap(),
+            NonZeroU32::new(modality_probe::GeneratedId::MAX_ID).unwrap(),
         )
         .unwrap();
         let probe_id_gen = IdGen::new(probe_id_range);
@@ -830,7 +830,7 @@ mod tests {
         };
         let probe_id_range = NonZeroIdRange::new(
             NonZeroU32::new(1).unwrap(),
-            NonZeroU32::new(modality_probe::ProbeId::MAX_ID).unwrap(),
+            NonZeroU32::new(modality_probe::GeneratedId::MAX_ID).unwrap(),
         )
         .unwrap();
         let probe_id_gen = IdGen::new(probe_id_range);

--- a/modality-probe-cli/src/manifest_gen/mod.rs
+++ b/modality-probe-cli/src/manifest_gen/mod.rs
@@ -54,7 +54,7 @@ pub struct ManifestGen {
     /// This can be either `<inclusive_start>..<exclusive_end>`
     /// or `<inclusive_start>..=<inclusive_end>`.
     ///
-    /// The range values are unsigned 32-bit integers and must be non-zero.
+    /// The range values are unsigned 24-bit integers and must be non-zero.
     #[structopt(long, parse(try_from_str = NonZeroIdRange::from_str))]
     pub probe_id_range: Option<NonZeroIdRange>,
 
@@ -135,8 +135,8 @@ pub fn run(opt: ManifestGen, internal_events: Option<Vec<Event>>) {
     let probe_id_range = opt.probe_id_range.unwrap_or_else(|| {
         NonZeroIdRange::new(
             NonZeroU32::new(1).unwrap(),
-            NonZeroU32::new(modality_probe::ProbeId::MAX_ID)
-                .unwrap_or_exit("Can't make a NonZeroU32 from ProbeId::MAX_ID"),
+            NonZeroU32::new(modality_probe::GeneratedId::MAX_ID)
+                .unwrap_or_exit("Can't make a NonZeroU32 from GeneratedId::MAX_ID"),
         )
         .unwrap_or_exit("Can't make a NonZeroIdRange from the given inclusive start and end values")
     });

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,38 @@ impl fmt::Display for InvalidProbeId {
     }
 }
 
+/// Error that indicates an invalid instance id portion of the probe id was detected.
+///
+///
+/// Instance ids must be less than InstanceId::MAX_ID
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InvalidInstanceId;
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidInstanceId {}
+
+impl fmt::Display for InvalidInstanceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Invalid InstanceId portion of a Probe Id")
+    }
+}
+
+/// Error that indicates an invalid generated id portion of the probe id was detected.
+///
+///
+/// Generated ids must be greater than 0 and less than GeneratedId::MAX_ID
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InvalidGeneratedId;
+
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidGeneratedId {}
+
+impl fmt::Display for InvalidGeneratedId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Invalid GeneratedId portion of a Probe Id")
+    }
+}
+
 /// Error that indicates an invalid wall clock time was detected.
 ///
 /// Wall clock time must not be greater than Nanoseconds::MAX

--- a/src/instance_id_gen.rs
+++ b/src/instance_id_gen.rs
@@ -1,0 +1,55 @@
+use crate::id::InstanceId;
+use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::Ordering::SeqCst;
+use static_assertions::{assert_eq_align, assert_eq_size, const_assert};
+
+assert_eq_size!(usize, InstanceIdGen);
+assert_eq_align!(usize, InstanceIdGen);
+const_assert!((InstanceId::MAX_ID as usize) < core::usize::MAX);
+
+/// Thread-safe InstanceId generator, values start at zero and stop at InstanceId::MAX_ID
+#[derive(Debug, Default)]
+#[repr(transparent)]
+pub struct InstanceIdGen(AtomicUsize);
+
+impl InstanceIdGen {
+    const MAX_ID: usize = InstanceId::MAX_ID as usize;
+
+    /// Create a new InstanceIdGen, the generated values start at zero and stop at InstanceId::MAX_ID
+    pub const fn new() -> Self {
+        InstanceIdGen(AtomicUsize::new(0))
+    }
+
+    /// Get the next available InstanceId, returns None if the id range has been exhausted
+    pub fn next(&self) -> Option<InstanceId> {
+        let id = self.0.fetch_update(SeqCst, SeqCst, |current_value| {
+            if current_value <= Self::MAX_ID {
+                Some(current_value + 1)
+            } else {
+                None
+            }
+        });
+        id.ok().map(|id| InstanceId::new(id as _)).flatten()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generates_full_range() {
+        let gen = InstanceIdGen::new();
+        for i in 0..=core::u8::MAX {
+            if i <= InstanceId::MAX_ID {
+                assert_eq!(i, u8::from(gen.next().unwrap()));
+            } else {
+                assert_eq!(None, gen.next());
+            }
+        }
+        for _ in 0..=core::u8::MAX {
+            assert_eq!(None, gen.next());
+        }
+        assert_eq!((InstanceId::MAX_ID as usize) + 1, gen.0.load(SeqCst));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use static_assertions::{assert_cfg, const_assert};
 pub use error::*;
 use history::DynamicHistory;
 pub use id::*;
+pub use instance_id_gen::*;
 #[cfg(feature = "std")]
 pub use prop::*;
 pub use restart_counter::{
@@ -32,6 +33,7 @@ pub use time::{NanosecondResolution, Nanoseconds, WallClockId};
 mod error;
 mod history;
 mod id;
+mod instance_id_gen;
 pub mod log;
 mod macros;
 mod restart_counter;


### PR DESCRIPTION
In order to deal with sibling/replicate probes, this PR splits up the ProbeId into a composite of
InstanceId and GeneratedId fields.

* `GeneratedId`: 24 bits, non-zero, generated by the CLI at build-time
* `InstanceId`: 6 bits, 0..=63, default is zero, set at runtime in probe initialization
* Reserved: 2 bits, reserved for use in the reporting protocol

The little-endian bit layout:
```text
 least significant                                              most significant
      ┊                                                             ┊
     ║┊ first byte   ║  second byte  ║  third byte   ║  fourth byte ┊║
     ╟───────────────╫───────────────╫───────────────╫───────────────╢
     ║▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒ ▒║
     ╟───────────────────────────────────────────────╫───────────╫───╢
     ║                  GeneratedId                  ║    ┊      ║ ┊ ║
                                                          ┊        ┊
                                                     InstanceId   reserved
```

### C API

Singleton-like:

```c
MODALITY_PROBE_INIT(
        MY_PROBE,
        ... other probe configs ...
        MODALITY_TAGS("LiDAR", "driver"),
        "XYZ LiDAR driver probe");
```

Multi-instance:

```c
/* Multi-instance probes can use InstanceIdGen to generate InstanceIds */
static modality_probe_instance_id_gen g_instance_id_gen = MODALITY_PROBE_INSTANCE_ID_GEN_INIT;

modality_probe_instance_id instance_id;
err = modality_probe_instance_id_gen_next(&g_instance_id_gen, &instance_id);
assert(err == MODALITY_PROBE_ERROR_OK);

MODALITY_PROBE_INIT(
        MY_PROBE(instance_id),  // <-- CLI detects this function-like syntax
        ... other probe configs ...
        MODALITY_TAGS("LiDAR", "driver"),  // CLI adds MULTI_INSTANCE
        "XYZ LiDAR driver probe");
```

### Rust API

Singleton-like:

```rust
let probe = initialize_at!(
    &mut storage,
    MY_PROBE,
    ... other probe configs ...
    tags!("LiDAR", "driver"),
    "XYZ LiDAR driver probe"
)?;
```

Multi-instance:

```rust
// Multi-instance probes can use InstanceIdGen to generate InstanceIds
static INSTANCE_ID_GEN: InstanceIdGen = InstanceIdGen::new();

let instance_id = INSTANCE_ID_GEN.next().expect("Exhausted InstanceId space");

let probe = initialize_at!(
    &mut storage,
    MY_PROBE(instance_id),                 // <-- CLI detects this function-like syntax
    ... other probe configs ...
    tags!("LiDAR", "driver"),
    "XYZ LiDAR driver probe"
)?;
```

- [ ] Pick a multi-instance display format for `visualize`
- [ ] Support multi-instance probes in `log`