### PR TITLE
Add failure event recording C and Rust macros, move severity specification to a separate helper macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,23 @@ expect!(
     PRODUCER_TX_STATUS_OK,
     tx_status.is_ok(),
     "Measurement producer send result status",
-    tags!("producer", "SEVERITY_10")
+    tags!("producer"),
+    severity!(10),
+);
+```
+
+### Recording Failures
+
+Failures are special events that get tagged as failures to
+denote "something bad happened".
+
+```rust
+failure!(
+    probe,
+    BAD_THING_HAPPENED,
+    tags!("problem"),
+    severity!(5),
+    "A bad thing happened",
 );
 ```
 

--- a/examples/c-example/src/main.c
+++ b/examples/c-example/src/main.c
@@ -158,7 +158,8 @@ static void run_producer(void)
             g_producer_probe,
             PRODUCER_SAMPLE_DELTA_OK,
             (sample - g_producer_measurement.m) <= 2,
-            MODALITY_TAGS("producer", "SEVERITY_10"),
+            MODALITY_TAGS("producer"),
+            MODALITY_SEVERITY(10),
             "Measurement delta within ok range");
     assert(err == MODALITY_PROBE_ERROR_OK);
 

--- a/examples/rust-example/src/main.rs
+++ b/examples/rust-example/src/main.rs
@@ -106,7 +106,8 @@ fn measurement_producer_thread(tx: crossbeam_channel::Sender<Measurement>) {
         PRODUCER_MEASUREMENT_SENT,
         tx_status.is_ok(),
         "Measurement producer sent a measurement",
-        tags!("producer", "transmit", "SEVERITY_10")
+        tags!("producer", "transmit"),
+        severity!(10)
     );
 
     record!(

--- a/modality-probe-capi/README.md
+++ b/modality-probe-capi/README.md
@@ -137,8 +137,23 @@ err = MODALITY_PROBE_EXPECT(
         g_producer_probe,
         PRODUCER_SAMPLE_DELTA_OK,
         (sample - g_producer_measurement.m) <= 2,
-        MODALITY_TAGS("producer", "SEVERITY_10"),
+        MODALITY_TAGS("producer"),
+        MODALITY_SEVERITY(10),
         "Measurement delta within ok range");
+```
+
+### Recording Failures
+
+Failures are special events that get tagged as failures to
+denote "something bad happened".
+
+```rust
+err = MODALITY_PROBE_FAILURE(
+        g_producer_probe,
+        BAD_THING_HAPPENED,
+        MODALITY_TAGS("problem"),
+        MODALITY_SEVERITY(5),
+        "A bad thing happened");
 ```
 
 ### Recording Wall Clock Time

--- a/modality-probe-capi/ctest/noop.c
+++ b/modality-probe-capi/ctest/noop.c
@@ -112,6 +112,13 @@ int main(void) {
 
     err = MODALITY_PROBE_EXPECT(g_probe, EVENT_A, 1 == 0);
     assert(err == MODALITY_PROBE_ERROR_OK);
+    err = MODALITY_PROBE_EXPECT(g_probe, EVENT_A, 1 == 0, MODALITY_SEVERITY(2));
+    assert(err == MODALITY_PROBE_ERROR_OK);
+
+    err = MODALITY_PROBE_FAILURE(g_probe, EVENT_A);
+    assert(err == MODALITY_PROBE_ERROR_OK);
+    err = MODALITY_PROBE_FAILURE(g_probe, EVENT_A, MODALITY_SEVERITY(3));
+    assert(err == MODALITY_PROBE_ERROR_OK);
 
     return 0;
 }

--- a/modality-probe-capi/ctest/test.c
+++ b/modality-probe-capi/ctest/test.c
@@ -132,7 +132,9 @@ bool test_event_recording(void) {
     ERROR_CHECK(result, passed);
     result = MODALITY_PROBE_RECORD_W_F32(t, EVENT_A, 1.23f, "my docs");
     ERROR_CHECK(result, passed);
-    result = MODALITY_PROBE_EXPECT(t, EVENT_A, 1 == 0, "my docs", MODALITY_TAGS("SEVERITY_10"));
+    result = MODALITY_PROBE_EXPECT(t, EVENT_A, 1 == 0, "my docs", MODALITY_TAGS("tag-a"), MODALITY_SEVERITY(10));
+    ERROR_CHECK(result, passed);
+    result = MODALITY_PROBE_FAILURE(t, EVENT_A, "my docs", MODALITY_TAGS("tag-a"), MODALITY_SEVERITY(10));
     ERROR_CHECK(result, passed);
     modality_probe_causal_snapshot snap_b;
     result = modality_probe_produce_snapshot(t, &snap_b);
@@ -163,8 +165,6 @@ bool test_event_recording(void) {
     result = MODALITY_PROBE_RECORD_W_BOOL_W_TIME(t, EVENT_A, true, 1, "my docs");
     ERROR_CHECK(result, passed);
     result = MODALITY_PROBE_RECORD_W_F32_W_TIME(t, EVENT_A, 1.23f, 1, "my docs");
-    ERROR_CHECK(result, passed);
-    result = MODALITY_PROBE_EXPECT(t, EVENT_A, 1 == 0, "my docs", MODALITY_TAGS("SEVERITY_10"));
     ERROR_CHECK(result, passed);
     result = modality_probe_produce_snapshot_with_time(t, 1, &snap_b);
     ERROR_CHECK(result, passed);

--- a/modality-probe-capi/include/probe.h
+++ b/modality-probe-capi/include/probe.h
@@ -182,6 +182,23 @@ typedef enum {
 #define MODALITY_TAGS(...)
 
 /*
+ * Modality probe severity level specifying macro.
+ *
+ * This is a no-op macro used to expose metadata to the CLI tooling.
+ *
+ * The levels are aligned with the FMEA severity ratings, going
+ * from one to ten, with one indicating negligible or nonexistent harm,
+ * and ten indicating a safety or regulatory hazard.
+ *
+ * Example use:
+ * ```c
+ * MODALITY_SEVERITY(1)
+ * ```
+ *
+ */
+#define MODALITY_SEVERITY(level)
+
+/*
  * Modality probe instance initializer macro.
  *
  * Used to expose probe information to the CLI tooling.
@@ -351,6 +368,7 @@ typedef enum {
  *
  * The trailing variadic macro arguments accept (in any order):
  * - Tags: MODALITY_TAGS(<tag>[,<tag>])
+ * - Severity level: MODALITY_SEVERITY(<level>)
  * - A string for the event description
  *
  * Event with payload descriptions may additionally use a single
@@ -363,6 +381,24 @@ typedef enum {
             probe, \
             event, \
             (expr)) : MODALITY_PROBE_ERROR_OK)
+
+/*
+ * Modality probe failure event recording macro.
+ *
+ * Used to expose failure event recording information to the CLI tooling.
+ *
+ * Expands to call `modality_probe_record(probe, event)`.
+ *
+ * The trailing variadic macro arguments accept (in any order):
+ * - Tags: MODALITY_TAGS(<tag>[,<tag>])
+ * - Severity level: MODALITY_SEVERITY(<level>)
+ * - A string for the event description
+ *
+ */
+#define MODALITY_PROBE_FAILURE(probe, event, ...) \
+    ((MODALITY_PROBE_MACROS_ENABLED) ? modality_probe_record_event(\
+            probe, \
+            event) : MODALITY_PROBE_ERROR_OK)
 
 /*
  * Create a Modality probe instance. probe_id must be non-zero.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -8,10 +8,16 @@ macro_rules! tags {
     ($tag:tt, $($more_tags:tt)+) => {};
 }
 
+/// No-op macro used to specify a severity level on failures or expectations.
+#[macro_export]
+macro_rules! severity {
+    ($tag:expr) => {};
+}
+
 /// Convenience macro that calls
 /// [ModalityProbe::initialize_at](struct.ModalityProbe.html#method.initialize_at).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export]
 macro_rules! initialize_at {
@@ -29,7 +35,7 @@ macro_rules! initialize_at {
 /// Convenience macro that calls
 /// [ModalityProbe::try_initialize_at](struct.ModalityProbe.html#method.try_initialize_at).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export]
 macro_rules! try_initialize_at {
@@ -47,7 +53,7 @@ macro_rules! try_initialize_at {
 /// Convenience macro that calls
 /// [ModalityProbe::new_with_storage](struct.ModalityProbe.html#method.new_with_storage).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export]
 macro_rules! new_with_storage {
@@ -65,7 +71,7 @@ macro_rules! new_with_storage {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event](struct.ModalityProbe.html#method.record_event).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export]
 macro_rules! record {
@@ -83,7 +89,7 @@ macro_rules! record {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event](struct.ModalityProbe.html#method.try_record_event).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export]
 macro_rules! try_record {
@@ -101,7 +107,7 @@ macro_rules! try_record {
 /// Convenience macro that calls
 /// [ModalityProbe::record_time](struct.ModalityProbe.html#method.record_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export]
 macro_rules! record_time {
@@ -119,7 +125,7 @@ macro_rules! record_time {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_time](struct.ModalityProbe.html#method.try_record_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export]
 macro_rules! try_record_time {
@@ -137,7 +143,7 @@ macro_rules! try_record_time {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_time](struct.ModalityProbe.html#method.record_event_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export]
 macro_rules! record_w_time {
@@ -155,7 +161,7 @@ macro_rules! record_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_time](struct.ModalityProbe.html#method.try_record_event_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export]
 macro_rules! try_record_w_time {
@@ -173,7 +179,7 @@ macro_rules! try_record_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload](struct.ModalityProbe.html#method.record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -195,7 +201,7 @@ macro_rules! record_w_i8 {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload_with_time](struct.ModalityProbe.html#method.record_event_with_payload_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_i8_w_time {
@@ -213,7 +219,7 @@ macro_rules! record_w_i8_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload](struct.ModalityProbe.html#method.record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -235,7 +241,7 @@ macro_rules! record_w_u8 {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload_with_time](struct.ModalityProbe.html#method.record_event_with_payload_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_u8_w_time {
@@ -253,7 +259,7 @@ macro_rules! record_w_u8_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload](struct.ModalityProbe.html#method.record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -275,7 +281,7 @@ macro_rules! record_w_i16 {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload_with_time](struct.ModalityProbe.html#method.record_event_with_payload_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_i16_w_time {
@@ -293,7 +299,7 @@ macro_rules! record_w_i16_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload](struct.ModalityProbe.html#method.record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -315,7 +321,7 @@ macro_rules! record_w_u16 {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload_with_time](struct.ModalityProbe.html#method.record_event_with_payload_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_u16_w_time {
@@ -333,7 +339,7 @@ macro_rules! record_w_u16_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload](struct.ModalityProbe.html#method.record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -355,7 +361,7 @@ macro_rules! record_w_i32 {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload_with_time](struct.ModalityProbe.html#method.record_event_with_payload_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_i32_w_time {
@@ -373,7 +379,7 @@ macro_rules! record_w_i32_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload](struct.ModalityProbe.html#method.record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -395,7 +401,7 @@ macro_rules! record_w_u32 {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload_with_time](struct.ModalityProbe.html#method.record_event_with_payload_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_u32_w_time {
@@ -413,7 +419,7 @@ macro_rules! record_w_u32_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload](struct.ModalityProbe.html#method.record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -435,7 +441,7 @@ macro_rules! record_w_bool {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload_with_time](struct.ModalityProbe.html#method.record_event_with_payload_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_bool_w_time {
@@ -453,7 +459,7 @@ macro_rules! record_w_bool_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload](struct.ModalityProbe.html#method.record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -475,7 +481,7 @@ macro_rules! record_w_f32 {
 /// Convenience macro that calls
 /// [ModalityProbe::record_event_with_payload_with_time](struct.ModalityProbe.html#method.record_event_with_payload_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! record_w_f32_w_time {
@@ -493,7 +499,7 @@ macro_rules! record_w_f32_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload](struct.ModalityProbe.html#method.try_record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -515,7 +521,7 @@ macro_rules! try_record_w_i8 {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload_with_time](struct.ModalityProbe.html#method.try_record_event_with_payload_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_i8_w_time {
@@ -533,7 +539,7 @@ macro_rules! try_record_w_i8_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload](struct.ModalityProbe.html#method.try_record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -555,7 +561,7 @@ macro_rules! try_record_w_u8 {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload_with_time](struct.ModalityProbe.html#method.try_record_event_with_payload_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_u8_w_time {
@@ -573,7 +579,7 @@ macro_rules! try_record_w_u8_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload](struct.ModalityProbe.html#method.try_record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -595,7 +601,7 @@ macro_rules! try_record_w_i16 {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload_with_time](struct.ModalityProbe.html#method.try_record_event_with_payload_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_i16_w_time {
@@ -613,7 +619,7 @@ macro_rules! try_record_w_i16_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload](struct.ModalityProbe.html#method.try_record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -635,7 +641,7 @@ macro_rules! try_record_w_u16 {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload_with_time](struct.ModalityProbe.html#method.try_record_event_with_payload_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_u16_w_time {
@@ -653,7 +659,7 @@ macro_rules! try_record_w_u16_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload](struct.ModalityProbe.html#method.try_record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -675,7 +681,7 @@ macro_rules! try_record_w_i32 {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload_with_time](struct.ModalityProbe.html#method.try_record_event_with_payload_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_i32_w_time {
@@ -693,7 +699,7 @@ macro_rules! try_record_w_i32_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload](struct.ModalityProbe.html#method.try_record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -715,7 +721,7 @@ macro_rules! try_record_w_u32 {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload_with_time](struct.ModalityProbe.html#method.try_record_event_with_payload_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_u32_w_time {
@@ -733,7 +739,7 @@ macro_rules! try_record_w_u32_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload](struct.ModalityProbe.html#method.try_record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -755,7 +761,7 @@ macro_rules! try_record_w_bool {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload_with_time](struct.ModalityProbe.html#method.try_record_event_with_payload_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_bool_w_time {
@@ -773,7 +779,7 @@ macro_rules! try_record_w_bool_w_time {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload](struct.ModalityProbe.html#method.try_record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -795,7 +801,7 @@ macro_rules! try_record_w_f32 {
 /// Convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload_with_time](struct.ModalityProbe.html#method.try_record_event_with_payload_with_time).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description and tag arguments are only used
 /// by the CLI and compile away.
 #[macro_export(local_inner_macros)]
 macro_rules! try_record_w_f32_w_time {
@@ -810,10 +816,10 @@ macro_rules! try_record_w_f32_w_time {
     }};
 }
 
-/// Convenience macro that calls
+/// Expectation expression recording convenience macro that calls
 /// [ModalityProbe::record_event_with_payload](struct.ModalityProbe.html#method.record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description, severity and tags arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -824,18 +830,21 @@ macro_rules! expect {
     ($probe:expr, $event:expr, $expression:expr) => {{
         __record_with!($probe, $event, $expression)
     }};
-    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags:expr) => {{
+    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags_or_severity:expr) => {{
         __record_with!($probe, $event, $expression)
     }};
-    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
+    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags_or_severity_0:expr, $desc_or_tags_or_severity_1:expr) => {{
+        __record_with!($probe, $event, $expression)
+    }};
+    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags_or_severity_0:expr, $desc_or_tags_or_severity_1:expr, $desc_or_tags_or_severity_2:expr) => {{
         __record_with!($probe, $event, $expression)
     }};
 }
 
-/// Convenience macro that calls
+/// Expectation expression recording convenience macro that calls
 /// [ModalityProbe::try_record_event_with_payload](struct.ModalityProbe.html#method.try_record_event_with_payload).
 ///
-/// The optional description and tags string arguments are only used
+/// The optional description, severity and tags arguments are only used
 /// by the CLI and compile away.
 ///
 /// Event with payload descriptions may additionally use a single
@@ -846,12 +855,57 @@ macro_rules! try_expect {
     ($probe:expr, $event:expr, $expression:expr) => {{
         __try_record_with!($probe, $event, $expression)
     }};
-    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags:expr) => {{
+    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags_or_severity:expr) => {{
         __try_record_with!($probe, $event, $expression)
     }};
-    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags:expr, $tags_or_desc:expr) => {{
+    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags_or_severity_0:expr, $desc_or_tags_or_severity_1:expr) => {{
         __try_record_with!($probe, $event, $expression)
     }};
+    ($probe:expr, $event:expr, $expression:expr, $desc_or_tags_or_severity_0:expr, $desc_or_tags_or_severity_1:expr, $desc_or_tags_or_severity_2:expr) => {{
+        __try_record_with!($probe, $event, $expression)
+    }};
+}
+
+/// Failure recording convenience macro that calls
+/// [ModalityProbe::record_event](struct.ModalityProbe.html#method.record_event).
+///
+/// The optional description and tag arguments are only used
+/// by the CLI and compile away.
+#[macro_export]
+macro_rules! failure {
+    ($probe:expr, $event:expr) => {
+        $probe.record_event($event)
+    };
+    ($probe:expr, $event:expr, $desc_or_tags_or_severity:expr) => {
+        $probe.record_event($event)
+    };
+    ($probe:expr, $event:expr, $desc_or_tags_or_severity_0:expr, $desc_or_tags_or_severity_1:expr) => {
+        $probe.record_event($event)
+    };
+    ($probe:expr, $event:expr, $desc_or_tags_or_severity_0:expr, $desc_or_tags_or_severity_1:expr, $desc_or_tags_or_severity_2:expr) => {
+        $probe.record_event($event)
+    };
+}
+
+/// Failure recording convenience macro that calls
+/// [ModalityProbe::try_record_event](struct.ModalityProbe.html#method.try_record_event).
+///
+/// The optional description and tag arguments are only used
+/// by the CLI and compile away.
+#[macro_export]
+macro_rules! try_failure {
+    ($probe:expr, $event:expr) => {
+        $probe.try_record_event($event)
+    };
+    ($probe:expr, $event:expr, $desc_or_tags_or_severity:expr) => {
+        $probe.try_record_event($event)
+    };
+    ($probe:expr, $event:expr, $desc_or_tags_or_severity_0:expr, $desc_or_tags_or_severity_1:expr) => {
+        $probe.try_record_event($event)
+    };
+    ($probe:expr, $event:expr, $desc_or_tags_or_severity_0:expr, $desc_or_tags_or_severity_1:expr, $desc_or_tags_or_severity_2:expr) => {
+        $probe.try_record_event($event)
+    };
 }
 
 #[doc(hidden)]
@@ -1135,8 +1189,16 @@ mod tests {
             probe,
             EventId::new(EVENT_D).unwrap(),
             "s1" != "s2",
-            tags!("SEVERITY_1"),
+            tags!("tag-a"),
             "desc"
+        );
+        expect!(
+            probe,
+            EventId::new(EVENT_D).unwrap(),
+            "s1" != "s2",
+            tags!("tag-a"),
+            "desc",
+            severity!(1)
         );
 
         try_expect!(probe, EVENT_D, true == true).unwrap();
@@ -1144,6 +1206,36 @@ mod tests {
         let a = 1;
         let b = 2;
         try_expect!(probe, EVENT_D, a != b, "desc", tags!("my expect tag")).unwrap();
+        try_expect!(
+            probe,
+            EVENT_D,
+            a != b,
+            "desc",
+            severity!(2),
+            tags!("my expect tag")
+        )
+        .unwrap();
+
+        failure!(probe, EventId::new(EVENT_D).unwrap());
+        failure!(probe, EventId::new(EVENT_D).unwrap(), "desc");
+        failure!(
+            probe,
+            EventId::new(EVENT_D).unwrap(),
+            tags!("tag-a"),
+            "desc"
+        );
+        failure!(
+            probe,
+            EventId::new(EVENT_D).unwrap(),
+            tags!("tag-a"),
+            severity!(4),
+            "desc"
+        );
+
+        try_failure!(probe, EVENT_D).unwrap();
+        try_failure!(probe, EVENT_D, "desc").unwrap();
+        try_failure!(probe, EVENT_D, "desc", tags!("my tag")).unwrap();
+        try_failure!(probe, EVENT_D, severity!(3), "desc", tags!("my tag")).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
* Failure event recording macros: `MODALITY_PROBE_FAILURE()` for C, `failure!()` / `try_failure()` for Rust
* A severity specifying macro: `MODALITY_SEVERITY(num)` for C, `severity!(num)` for Rust