### PR TITLE
Pull nightly version from rust-toolchain file in CI workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,19 +15,26 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
+      - name: Find needed nightly toolchain version
+        id: rust_nightly_version
+        run: |
+          OUT=$(cat modality-probe-capi/rust-toolchain)
+          echo "$OUT"
+          echo "##[set-output name=toolchain;]$OUT"
+
+      - name: Install needed nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          components: rustfmt, clippy
+          toolchain: ${{ steps.rust_nightly_version.outputs.toolchain }}
+          override: true
+
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
-      - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2020-10-07
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,19 +13,26 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
+      - name: Find needed nightly toolchain version
+        id: rust_nightly_version
+        run: |
+          OUT=$(cat modality-probe-capi/rust-toolchain)
+          echo "$OUT"
+          echo "##[set-output name=toolchain;]$OUT"
+
+      - name: Install needed nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          components: rustfmt, clippy, llvm-tools-preview
+          toolchain: ${{ steps.rust_nightly_version.outputs.toolchain }}
+          override: true
+
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
-          override: true
-          components: rustfmt, clippy, llvm-tools-preview
-
-      - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
           override: true
           components: rustfmt, clippy, llvm-tools-preview
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,19 +50,26 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
+      - name: Find needed nightly toolchain version
+        id: rust_nightly_version
+        run: |
+          OUT=$(cat modality-probe-capi/rust-toolchain)
+          echo "$OUT"
+          echo "##[set-output name=toolchain;]$OUT"
+
+      - name: Install needed nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          components: rustfmt, clippy, llvm-tools-preview
+          toolchain: ${{ steps.rust_nightly_version.outputs.toolchain }}
+          override: true
+
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
-          override: true
-          components: rustfmt, clippy, llvm-tools-preview
-
-      - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
           override: true
           components: rustfmt, clippy, llvm-tools-preview
 

--- a/.github/workflows/weekly_fuzz.yml
+++ b/.github/workflows/weekly_fuzz.yml
@@ -30,6 +30,23 @@ jobs:
         if: steps.check_sha.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
 
+      - name: Find needed nightly toolchain version
+        if: steps.check_sha.outputs.cache-hit != 'true'
+        id: rust_nightly_version
+        run: |
+          OUT=$(cat modality-probe-capi/rust-toolchain)
+          echo "$OUT"
+          echo "##[set-output name=toolchain;]$OUT"
+
+      - name: Install nightly toolchain
+        if: steps.check_sha.outputs.cache-hit != 'true'
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ steps.rust_nightly_version.outputs.toolchain }}
+          override: true
+          components: rustfmt, clippy
+
       - name: Install stable toolchain
         if: steps.check_sha.outputs.cache-hit != 'true'
         uses: actions-rs/toolchain@v1
@@ -39,14 +56,18 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: Install nightly toolchain
+      - name: Print tool versions
         if: steps.check_sha.outputs.cache-hit != 'true'
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2020-10-07
-          override: true
-          components: rustfmt, clippy
+        run: |
+          echo `rustup default`
+          echo `which rustc`
+          echo `which cargo`
+          echo `which cargo-clippy`
+          echo `which cargo-fmt`
+          echo `rustc --version`
+          echo `cargo --version`
+          echo `cargo-clippy --version`
+          echo `cargo-fmt --version`
 
       - name: Fetch dependencies
         if: steps.check_sha.outputs.cache-hit != 'true'


### PR DESCRIPTION
Grab the nightly toolchain from the rust-toolchain file rather than hard coded in the workflows.
