### PR TITLE
Clippy lints for rustc 1.51.0

### DIFF
--- a/collectors/modality-probe-collector-common/Cargo.toml
+++ b/collectors/modality-probe-collector-common/Cargo.toml
@@ -16,4 +16,4 @@ fenced-ring-buffer = { path = "../../fenced-ring-buffer" }
 
 [dev-dependencies]
 proptest = { version = "1.0", default-features = false, features = ["std"]}
-pretty_assertions = "0.6"
+pretty_assertions = "0.7"

--- a/collectors/modality-probe-collector-common/src/json.rs
+++ b/collectors/modality-probe-collector-common/src/json.rs
@@ -34,7 +34,7 @@ pub fn read_log_entries<R: Read>(r: &mut R) -> Result<Vec<ReportLogEntry>, Error
             Err(e) => Err(Error::Serialization(format!("unable to read log: {}", e))),
         })
         .collect();
-    Ok(entries?)
+    entries
 }
 
 #[cfg(test)]

--- a/collectors/modality-probe-collector-common/src/lib.rs
+++ b/collectors/modality-probe-collector-common/src/lib.rs
@@ -30,9 +30,9 @@ macro_rules! newtype {
             }
         }
 
-        impl Into<$t> for &$name {
-            fn into(self) -> $t {
-                self.0
+        impl From<&$name> for $t {
+            fn from(val: &$name) -> $t {
+                val.0
             }
         }
     };

--- a/collectors/modality-probe-debug-collector/Cargo.toml
+++ b/collectors/modality-probe-debug-collector/Cargo.toml
@@ -21,14 +21,14 @@ path = "src/lib.rs"
 goblin = "0.2.3"
 chrono = { version = "0.4", features = ["serde"] }
 structopt = "0.3"
-parse_duration = "2.1.0"
+humantime = "2.1"
 probe-rs = "0.8"
 maplit = "1.0.2"
 tempfile = "3.1.0"
 err-derive = "0.3"
 ctrlc = "3.1.6"
 crossbeam-channel = "0.4.3"
-pretty_assertions = "0.6"
+pretty_assertions = "0.7"
 
 fenced-ring-buffer = { path = "../../fenced-ring-buffer", features = ["std"] }
 modality-probe = { path = "../..", features = ["debug-collector-access"] }

--- a/collectors/modality-probe-debug-collector/src/cli.rs
+++ b/collectors/modality-probe-debug-collector/src/cli.rs
@@ -130,12 +130,12 @@ pub(crate) fn config_from_options(options: Opts) -> Result<Config, CliError> {
         return Err(CliError::MissingElfFileError);
     }
 
-    let interval = parse_duration::parse(&options.interval_duration)
+    let interval = humantime::parse_duration(&options.interval_duration)
         .map_err(|_e| CliError::InvalidDuration(options.interval_duration.to_string()))?;
 
     let init_timeout = if let Some(timeout) = options.init_timeout.as_ref() {
         Some(
-            parse_duration::parse(timeout)
+            humantime::parse_duration(timeout)
                 .map_err(|_e| CliError::InvalidDuration(timeout.to_string()))?,
         )
     } else {

--- a/collectors/modality-probe-debug-collector/src/cli.rs
+++ b/collectors/modality-probe-debug-collector/src/cli.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use std::fs::File;
 use std::io::prelude::*;
 use std::net::SocketAddrV4;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
 use goblin::elf::Elf;
@@ -193,7 +193,7 @@ fn parse_probe_address(input: &str, use_64_bit: bool) -> Result<Option<ProbeAddr
 }
 
 /// Open elf file for parsing
-fn open_elf<'a>(path: &PathBuf, elf_buf: &'a mut Vec<u8>) -> Result<Elf<'a>, CliError> {
+fn open_elf<'a>(path: &Path, elf_buf: &'a mut Vec<u8>) -> Result<Elf<'a>, CliError> {
     let mut file = File::open(path).map_err(|_e| CliError::ElfFileError)?;
     file.read_to_end(elf_buf)
         .map_err(|_e| CliError::ElfFileError)?;

--- a/collectors/modality-probe-debug-collector/src/lib.rs
+++ b/collectors/modality-probe-debug-collector/src/lib.rs
@@ -52,20 +52,20 @@ impl Word {
     }
 }
 
-impl Into<usize> for Word {
-    fn into(self) -> usize {
-        match self {
-            Self::U32(n) => n as usize,
-            Self::U64(n) => n as usize,
+impl From<Word> for usize {
+    fn from(w: Word) -> Self {
+        match w {
+            Word::U32(n) => n as usize,
+            Word::U64(n) => n as usize,
         }
     }
 }
 
-impl Into<u64> for Word {
-    fn into(self) -> u64 {
-        match self {
-            Self::U32(n) => n as u64,
-            Self::U64(n) => n,
+impl From<Word> for u64 {
+    fn from(w: Word) -> Self {
+        match w {
+            Word::U32(n) => n as u64,
+            Word::U64(n) => n,
         }
     }
 }

--- a/collectors/modality-probe-offline-batch-collector/src/lib.rs
+++ b/collectors/modality-probe-offline-batch-collector/src/lib.rs
@@ -129,7 +129,7 @@ impl<'a, I: Read, O: Write> OfflineBatchCollector<'a, I, O> {
                 let slice = &bytes[idx..];
                 if slice.len() >= self.fingerprint_len {
                     fingerprint_offsets_checked += 1;
-                    let r = WireReport::new_unchecked(&slice[..]);
+                    let r = WireReport::new_unchecked(slice);
                     if r.check_fingerprint().is_ok() {
                         fingerprint_offset = Some(idx);
                         debug!(
@@ -188,7 +188,7 @@ impl<'a, I: Read, O: Write> OfflineBatchCollector<'a, I, O> {
                 Some(fingerprint_offset) => {
                     bytes_consumed += fingerprint_offset;
                     let slice = &bytes[fingerprint_offset..];
-                    let r = WireReport::new_unchecked(&slice[..]);
+                    let r = WireReport::new_unchecked(slice);
                     if r.check_len().is_ok() && r.check_payload_len().is_ok() {
                         let payload_len = r.payload_len();
                         let report_size = self.header_len + payload_len;

--- a/collectors/modality-probe-udp-collector/Cargo.toml
+++ b/collectors/modality-probe-udp-collector/Cargo.toml
@@ -43,5 +43,5 @@ lazy_static = "1.4.0"
 proc-graph = "0.1.0"
 proptest = { version = "1.0", default-features = false, features = ["std"]}
 tempfile = "3"
-pretty_assertions = "0.6"
+pretty_assertions = "0.7"
 modality-probe = { path = "../../" }

--- a/modality-probe-cli/Cargo.toml
+++ b/modality-probe-cli/Cargo.toml
@@ -81,7 +81,7 @@ features = ["curly"]
 nix = "0.20.0"
 
 [dev-dependencies]
-pretty_assertions = "0.6"
+pretty_assertions = "0.7"
 tempfile = "3.1"
 proptest = { version = "1.0", default-features = false, features = ["std"]}
 modality-probe-graph = { path = "../modality-probe-graph", features = ["test_support"] }

--- a/modality-probe-cli/src/visualize/graph.rs
+++ b/modality-probe-cli/src/visualize/graph.rs
@@ -470,7 +470,7 @@ pub(crate) mod test {
             .as_complete()
             .dot(&cfg, "complete", templates::COMPLETE)
             .unwrap();
-        assert!(dot.contains("one_one_1_1 ->\n    two_two_1_3"), dot);
+        assert!(dot.contains("one_one_1_1 ->\n    two_two_1_3"), "{}", dot);
     }
 
     #[test]
@@ -486,7 +486,7 @@ pub(crate) mod test {
             .as_interactions()
             .dot(&cfg, "interactions", templates::INTERACTIONS)
             .unwrap();
-        assert!(dot.contains("one_0 -> two_1"), dot);
+        assert!(dot.contains("one_0 -> two_1"), "{}", dot);
     }
 
     #[test]
@@ -502,7 +502,7 @@ pub(crate) mod test {
             .as_states()
             .dot(&cfg, "states", templates::STATES)
             .unwrap();
-        assert!(dot.contains("one_AT_one ->\n    two_AT_two"), dot);
+        assert!(dot.contains("one_AT_one ->\n    two_AT_two"), "{}", dot);
     }
 
     #[test]
@@ -518,6 +518,6 @@ pub(crate) mod test {
             .as_topology()
             .dot(&cfg, "topo", templates::TOPO)
             .unwrap();
-        assert!(dot.contains("one -> two"), dot);
+        assert!(dot.contains("one -> two"), "{}", dot);
     }
 }


### PR DESCRIPTION
Also addresses:
```
ID:       RUSTSEC-2021-0041
Crate:    parse_duration
Version:  2.1.1
Date:     2021-03-18
URL:      https://rustsec.org/advisories/RUSTSEC-2021-0041
Title:    Denial of service through parsing payloads with too big exponent
Solution:  No safe upgrade is available!
Dependency tree: 
parse_duration 2.1.1
└── modality-probe-debug-collector 0.1.0

warning: 1 warning found

Crate:  difference
Title:  difference is unmaintained
Date:   2020-12-20
URL:    https://rustsec.org/advisories/RUSTSEC-2020-0095
Dependency tree: 
difference 2.0.0
└── pretty_assertions 0.6.1
    ├── modality-probe-udp-collector 0.3.0
    ├── modality-probe-debug-collector 0.1.0
    ├── modality-probe-collector-common 0.1.0
    │   ├── modality-probe-udp-collector 0.3.0
    │   ├── modality-probe-offline-batch-collector 0.1.0
    │   ├── modality-probe-graph 0.1.0
    │   │   └── modality-probe-cli 0.3.0
    │   ├── modality-probe-debug-collector 0.1.0
    │   └── modality-probe-cli 0.3.0
    └── modality-probe-cli 0.3.0
```