### PR TITLE
Add verbose flag to manifest-gen CLI subcommand

### DIFF
--- a/examples/c-example/Makefile
+++ b/examples/c-example/Makefile
@@ -41,6 +41,7 @@ probe-utils:
 gen-manifest:
 	@../../target/debug/modality-probe \
 		manifest-gen \
+		--verbose \
 		--lang C \
 		--file-extension="c" \
 		--component-name "example-component" \

--- a/examples/rust-example/build.rs
+++ b/examples/rust-example/build.rs
@@ -21,6 +21,7 @@ fn main() {
     let status = Command::new(&cli)
         .args(&[
             "manifest-gen",
+            "--verbose",
             "--lang",
             "rust",
             "--file-extension",

--- a/modality-probe-cli/src/header_gen.rs
+++ b/modality-probe-cli/src/header_gen.rs
@@ -20,6 +20,7 @@ use structopt::{clap, StructOpt};
 #[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
 #[structopt(setting = clap::AppSettings::UnifiedHelpMessage)]
 #[structopt(setting = clap::AppSettings::ColoredHelp)]
+#[structopt(help_message = "Prints help information. Use --help for more details.")]
 pub struct HeaderGen {
     /// The language to output the source in. Either `c' or `rust'.
     #[structopt(short, long, parse(try_from_str), default_value = "C")]
@@ -372,7 +373,7 @@ pub fn generate_output<W: io::Write>(
 
     if let Some(p) = &opt.output_path {
         println!(
-            "Generated definitions for component {} in {}",
+            "Generated definitions for component '{}' in {}",
             component.name,
             p.display(),
         );

--- a/modality-probe-cli/src/lib.rs
+++ b/modality-probe-cli/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings, clippy::all)]
+
 pub mod component;
 pub mod description_format;
 pub mod error;

--- a/modality-probe-cli/src/log/mod.rs
+++ b/modality-probe-cli/src/log/mod.rs
@@ -31,6 +31,7 @@ use radius::Radius;
 #[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
 #[structopt(setting = clap::AppSettings::UnifiedHelpMessage)]
 #[structopt(setting = clap::AppSettings::ColoredHelp)]
+#[structopt(help_message = "Prints help information. Use --help for more details.")]
 pub struct Log {
     /// The probe to target. If no probe is given, the log from all
     /// probes is interleaved.

--- a/modality-probe-cli/src/main.rs
+++ b/modality-probe-cli/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(warnings, clippy::all)]
+
 use modality_probe_cli::{
     error::GracefulExit, header_gen, log, manifest_gen, opts::Opts, visualize,
 };

--- a/modality-probe-cli/src/manifest_gen/invocations.rs
+++ b/modality-probe-cli/src/manifest_gen/invocations.rs
@@ -45,6 +45,7 @@ pub enum EventCheckError {
 }
 
 pub struct Invocations {
+    verbose: bool,
     internal_events: Vec<Event>,
     probes: Vec<InSourceProbe>,
     events: Vec<InSourceEvent>,
@@ -55,6 +56,7 @@ impl Default for Invocations {
     fn default() -> Self {
         let config = Config::default();
         Invocations {
+            verbose: config.verbose,
             internal_events: config.internal_events,
             probes: Default::default(),
             events: Default::default(),
@@ -64,6 +66,7 @@ impl Default for Invocations {
 }
 
 pub struct Config<'cfg> {
+    pub verbose: bool,
     pub lang: Option<Lang>,
     pub c_parser: CParser<'cfg>,
     pub rust_parser: RustParser<'cfg>,
@@ -75,6 +78,7 @@ pub struct Config<'cfg> {
 impl<'cfg> Default for Config<'cfg> {
     fn default() -> Self {
         Config {
+            verbose: false,
             lang: None,
             c_parser: CParser::default(),
             rust_parser: RustParser::default(),
@@ -198,6 +202,7 @@ impl Invocations {
 
         let code_hash_bytes: [u8; 32] = *(code_hasher.finalize().as_ref());
         Ok(Invocations {
+            verbose: config.verbose,
             internal_events: config.internal_events,
             probes,
             events,
@@ -307,12 +312,14 @@ impl Invocations {
 
             if mf_probes.probes.iter().find(|t| src_probe.eq(t)).is_none() {
                 let probe = src_probe.to_probe(next_probe_id);
-                println!(
-                    "Adding probe {}, ID {} to {}",
-                    probe.name,
-                    probe.id.0,
-                    mf_path.display(),
-                );
+                if self.verbose {
+                    println!(
+                        "Adding probe {}, ID {} to {}",
+                        probe.name,
+                        probe.id.0,
+                        mf_path.display(),
+                    );
+                }
                 mf_probes.probes.push(probe);
             }
         });
@@ -452,12 +459,14 @@ impl Invocations {
         self.events.iter().for_each(|src_event| {
             if mf_events.events.iter().find(|e| src_event.eq(e)).is_none() {
                 let event = src_event.to_event(EventId(next_available_event_id));
-                println!(
-                    "Adding event {}, ID {} to {}",
-                    event.name,
-                    event.id.0,
-                    mf_path.display(),
-                );
+                if self.verbose {
+                    println!(
+                        "Adding event {}, ID {} to {}",
+                        event.name,
+                        event.id.0,
+                        mf_path.display(),
+                    );
+                }
                 mf_events.events.push(event);
                 next_available_event_id += 1;
             }

--- a/modality-probe-cli/src/manifest_gen/mod.rs
+++ b/modality-probe-cli/src/manifest_gen/mod.rs
@@ -34,7 +34,12 @@ pub mod type_hint;
 #[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
 #[structopt(setting = clap::AppSettings::UnifiedHelpMessage)]
 #[structopt(setting = clap::AppSettings::ColoredHelp)]
+#[structopt(help_message = "Prints help information. Use --help for more details.")]
 pub struct ManifestGen {
+    /// Provide (more) verbose output.
+    #[structopt(short, long)]
+    pub verbose: bool,
+
     /// Language (C or Rust), if not specified then guess based on file extensions
     #[structopt(short, long, parse(try_from_str))]
     pub lang: Option<Lang>,
@@ -80,6 +85,7 @@ pub struct ManifestGen {
 impl Default for ManifestGen {
     fn default() -> Self {
         ManifestGen {
+            verbose: false,
             lang: None,
             file_extensions: None,
             exclude_patterns: None,
@@ -125,6 +131,7 @@ pub fn run(opt: ManifestGen, internal_events: Option<Vec<Event>>) {
     events.validate_unique_names();
 
     let config = Config {
+        verbose: opt.verbose,
         lang: opt.lang,
         file_extensions: opt.file_extensions,
         exclude_patterns: opt.exclude_patterns,
@@ -196,7 +203,7 @@ pub fn run(opt: ManifestGen, internal_events: Option<Vec<Event>>) {
     probes.write_csv(&probes_manifest_path);
 
     println!(
-        "Updated component {} in {}",
+        "Updated component '{}' in {}",
         component_manifest.name,
         component_manifest_path.display()
     );

--- a/modality-probe-cli/src/opts.rs
+++ b/modality-probe-cli/src/opts.rs
@@ -14,6 +14,7 @@ pub(crate) const CLI_TEMPLATE: &str = "\
 #[structopt(setting = clap::AppSettings::DisableHelpSubcommand)]
 #[structopt(setting = clap::AppSettings::UnifiedHelpMessage)]
 #[structopt(setting = clap::AppSettings::ColoredHelp)]
+#[structopt(help_message = "Prints help information. Use --help for more details.")]
 pub enum Opts {
     /// Generate component, event and probe manifest files from probe macro invocations
     ManifestGen(ManifestGen),
@@ -44,6 +45,7 @@ mod test {
         assert_eq!(
             Opts::from_iter(["modality-probe", "manifest-gen", "/path",].iter()),
             Opts::ManifestGen(ManifestGen {
+                verbose: false,
                 lang: None,
                 file_extensions: None,
                 exclude_patterns: None,
@@ -60,6 +62,7 @@ mod test {
                 [
                     "modality-probe",
                     "manifest-gen",
+                    "-v",
                     "--lang",
                     "c",
                     "--event-id-offset",
@@ -79,6 +82,7 @@ mod test {
                 .iter()
             ),
             Opts::ManifestGen(ManifestGen {
+                verbose: true,
                 lang: Some(Lang::C),
                 event_id_offset: Some(10),
                 file_extensions: Some(vec!["c".to_string(), "cpp".to_string()]),

--- a/modality-probe-cli/src/visualize/mod.rs
+++ b/modality-probe-cli/src/visualize/mod.rs
@@ -20,6 +20,7 @@ mod templates;
 #[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
 #[structopt(setting = clap::AppSettings::UnifiedHelpMessage)]
 #[structopt(setting = clap::AppSettings::ColoredHelp)]
+#[structopt(help_message = "Prints help information. Use --help for more details.")]
 pub struct Visualize {
     /// Generate the graph showing only the causal relationships,
     /// eliding the events in between.


### PR DESCRIPTION
* Update the CLI help messages
* Move the verbose probe/event entry output behind a verbose flag in manifest-gen subcommand