### PR TITLE
Optional serialization support derived for time types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ readme = "README.md"
 
 [features]
 default = []
-std = ["serde", "proptest", "schemars"]
+std = ["serde", "schemars"]
+test_support = ["proptest"]
 debug-collector-access = ["field-offset"]
 
 [workspace]
@@ -41,8 +42,11 @@ fenced-ring-buffer = { path = "./fenced-ring-buffer" }
 
 # Used if the std feature is enabled.
 serde = { version = "1.0", features = ["derive"], optional = true }
-proptest = { version = "1.0", optional = true , default-features = false, features = ["std"]}
+proptest = { version = "1.0", optional = true , default-features = false}
 schemars = { version = "0.6.5", optional = true }
 
 # Used if the debug-collector-access feature is enabled
 field-offset = { version = "0.3.1", optional = true }
+
+[dev-dependencies]
+proptest = { version = "1.0", default-features = false, features = ["std"]}

--- a/collectors/modality-probe-collector-common/Cargo.toml
+++ b/collectors/modality-probe-collector-common/Cargo.toml
@@ -11,9 +11,10 @@ serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 err-derive = "0.3"
 
-modality-probe = { path = "../../", features = ["std"] }
+modality-probe = { path = "../..", features = ["std"] }
 fenced-ring-buffer = { path = "../../fenced-ring-buffer" }
 
 [dev-dependencies]
 proptest = { version = "1.0", default-features = false, features = ["std"]}
 pretty_assertions = "0.7"
+modality-probe = { path = "../..", features = ["std", "test_support"] }

--- a/collectors/modality-probe-collector-common/src/lib.rs
+++ b/collectors/modality-probe-collector-common/src/lib.rs
@@ -6,6 +6,7 @@ use fenced_ring_buffer::WholeEntry;
 use serde::{Deserialize, Serialize};
 use static_assertions::assert_eq_size;
 
+use modality_probe::wire::SequenceNumber;
 use modality_probe::{
     log::LogEntry,
     time::{
@@ -48,15 +49,12 @@ newtype! {
     pub struct SessionId(pub u32);
 }
 
-newtype! {
-    /// A log report sequence number
-    #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Hash, Copy, Clone, Ord, PartialOrd)]
-    pub struct SequenceNumber(pub u64);
+pub trait SequenceNumberExt {
+    fn prev(&self) -> Self;
 }
-
-impl SequenceNumber {
+impl SequenceNumberExt for SequenceNumber {
     /// Get the sequence number which preceded this one.
-    pub fn prev(&self) -> Self {
+    fn prev(&self) -> Self {
         SequenceNumber(self.0.saturating_sub(1))
     }
 }
@@ -726,7 +724,7 @@ impl Report {
             self.probe_clock.epoch,
             self.probe_clock.ticks,
         ));
-        wire.set_seq_num(self.seq_num.0);
+        wire.set_seq_num(self.seq_num);
         wire.set_persistent_epoch_counting(self.persistent_epoch_counting);
         wire.set_time_resolution(self.time_resolution);
         wire.set_wall_clock_id(self.wall_clock_id);

--- a/collectors/modality-probe-collector-common/src/lib.rs
+++ b/collectors/modality-probe-collector-common/src/lib.rs
@@ -475,7 +475,7 @@ impl TryFrom<&[u8]> for Report {
         let mut owned_report = Report {
             probe_id: id,
             probe_clock: LogicalClock { id, epoch, ticks },
-            seq_num: report.seq_num().into(),
+            seq_num: report.seq_num(),
             persistent_epoch_counting: report.persistent_epoch_counting(),
             time_resolution: report.time_resolution(),
             wall_clock_id: report.wall_clock_id(),

--- a/collectors/modality-probe-debug-collector/src/lib.rs
+++ b/collectors/modality-probe-debug-collector/src/lib.rs
@@ -598,11 +598,12 @@ pub mod tests {
     use std::convert::TryInto;
     use std::ptr;
 
+    use modality_probe::wire::SequenceNumber;
     use modality_probe::{
         time::{NanosecondResolution, Nanoseconds, WallClockId},
         EventId, ModalityProbe, Probe, RestartCounterProvider,
     };
-    use modality_probe_collector_common::{EventLogEntry, SequenceNumber};
+    use modality_probe_collector_common::EventLogEntry;
     use std::mem::MaybeUninit;
 
     fn lc(probe_id: u32, epoch: u16, ticks: u16) -> LogicalClock {

--- a/collectors/modality-probe-offline-batch-collector/src/lib.rs
+++ b/collectors/modality-probe-offline-batch-collector/src/lib.rs
@@ -9,9 +9,10 @@ use std::path::PathBuf;
 use buf_redux::BufReader;
 use chrono::Utc;
 use log::{debug, warn};
+use modality_probe::wire::SequenceNumber;
 use modality_probe::{wire::WireReport, ProbeId};
 use modality_probe_collector_common::{
-    self as common, json, Report, ReportLogEntry, SequenceNumber, SessionId,
+    self as common, json, Report, ReportLogEntry, SequenceNumberExt, SessionId,
 };
 use structopt::{clap, StructOpt};
 

--- a/modality-probe-cli/src/log/graph.rs
+++ b/modality-probe-cli/src/log/graph.rs
@@ -670,11 +670,12 @@ pub(crate) mod test {
     use chrono::Utc;
 
     use modality_probe::{EventId, NanosecondResolution, ProbeEpoch, ProbeTicks, WallClockId};
-    use modality_probe_collector_common::{SequenceNumber, SessionId};
+    use modality_probe_collector_common::SessionId;
 
     use crate::{log, visualize::graph};
 
     use super::*;
+    use modality_probe::wire::SequenceNumber;
 
     pub fn trace() -> Vec<ReportLogEntry> {
         let now = Utc::now();

--- a/modality-probe-cli/src/log/radius.rs
+++ b/modality-probe-cli/src/log/radius.rs
@@ -5,11 +5,12 @@ use std::{
 };
 
 use modality_probe::{LogicalClock, ProbeId};
-use modality_probe_collector_common::{LogEntryData, ReportLogEntry, SequenceNumber};
+use modality_probe_collector_common::{LogEntryData, ReportLogEntry};
 
 use crate::{error::CmdError, give_up, hopefully, hopefully_ok};
 
 use super::SortedProbes;
+use modality_probe::wire::SequenceNumber;
 
 #[derive(PartialEq, Debug)]
 pub struct Radius {

--- a/modality-probe-graph/src/lib.rs
+++ b/modality-probe-graph/src/lib.rs
@@ -5,8 +5,8 @@ use std::{collections::HashMap, hash::Hash};
 
 use err_derive::Error;
 
-use modality_probe::{EventId, LogicalClock, ProbeId};
-use modality_probe_collector_common::{EventLogEntry, Report, SequenceNumber};
+use modality_probe::{wire::report::SequenceNumber, EventId, LogicalClock, ProbeId};
+use modality_probe_collector_common::{EventLogEntry, Report, SequenceNumberExt};
 
 /// A trait for the inner graph type of `EventDiagraph`. This enables
 /// a custom inner graph that can be purpose built for a use-case, but
@@ -241,11 +241,10 @@ pub mod test_support {
     use chrono::prelude::*;
 
     use modality_probe::{
-        EventId, LogicalClock, NanosecondResolution, ProbeEpoch, ProbeId, ProbeTicks, WallClockId,
+        wire::report::SequenceNumber, EventId, LogicalClock, NanosecondResolution, ProbeEpoch,
+        ProbeId, ProbeTicks, WallClockId,
     };
-    use modality_probe_collector_common::{
-        LogEntryData, ReportLogEntry, SequenceNumber, SessionId,
-    };
+    use modality_probe_collector_common::{LogEntryData, ReportLogEntry, SessionId};
 
     //   1
     //  / \   |
@@ -638,11 +637,10 @@ mod test {
     use chrono::prelude::*;
 
     use modality_probe::{
-        EventId, LogicalClock, NanosecondResolution, ProbeEpoch, ProbeId, ProbeTicks, WallClockId,
+        wire::report::SequenceNumber, EventId, LogicalClock, NanosecondResolution, ProbeEpoch,
+        ProbeId, ProbeTicks, WallClockId,
     };
-    use modality_probe_collector_common::{
-        LogEntryData, ReportIter, ReportLogEntry, SequenceNumber, SessionId,
-    };
+    use modality_probe_collector_common::{LogEntryData, ReportIter, ReportLogEntry, SessionId};
 
     use super::*;
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -1040,7 +1040,8 @@ mod test {
         // Drain into a buffer that is ~1/4 of the log buffer capacity
         let report_buffer_size =
             WireReport::<&[u8]>::buffer_len(h.clocks.len(), h.log.capacity() / 4);
-        let mut report_dest = vec![0_u8; report_buffer_size];
+        let mut report_dest_underlying = [0_u8; 256];
+        let mut report_dest = &mut report_dest_underlying[..report_buffer_size];
 
         let mut reported_log_entries = 0;
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -502,7 +502,7 @@ impl<'a> DynamicHistory<'a> {
         // We can't store at least the frontier clocks and a pair of
         // two-word items.
         if report.as_ref().len() < WireReport::<&[u8]>::buffer_len(self.clocks.len(), 4) {
-            report.set_seq_num(self.report_seq_num);
+            report.set_seq_num(self.report_seq_num.into());
             report.set_n_clocks(0);
             report.set_n_log_entries(1);
             let payload = report.payload_mut();
@@ -513,7 +513,7 @@ impl<'a> DynamicHistory<'a> {
             );
         } else {
             let clocks_len = self.clocks.len();
-            report.set_seq_num(self.report_seq_num);
+            report.set_seq_num(self.report_seq_num.into());
             report.set_n_clocks(clocks_len as u16);
 
             let payload = report.payload_mut();

--- a/src/log.rs
+++ b/src/log.rs
@@ -183,19 +183,7 @@ impl fenced_ring_buffer::Entry for LogEntry {
 #[cfg(test)]
 pub(crate) mod log_tests {
     use super::*;
-    use crate::id::id_tests::*;
     use crate::{ProbeEpoch, ProbeId, ProbeTicks};
-    use proptest::prelude::*;
-
-    prop_compose! {
-        pub(crate) fn gen_clock()(
-            id in gen_probe_id(),
-            epoch in gen_probe_epoch(),
-            ticks in gen_probe_ticks()
-        ) -> LogicalClock {
-            LogicalClock { id, epoch, ticks }
-        }
-    }
 
     #[test]
     fn expected_representation() {

--- a/src/time.rs
+++ b/src/time.rs
@@ -9,8 +9,8 @@
 /// This can represent approximately 73 years.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(
-feature = "std",
-derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
+    feature = "std",
+    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
 )]
 #[repr(transparent)]
 pub struct Nanoseconds(u64);
@@ -18,8 +18,8 @@ pub struct Nanoseconds(u64);
 /// Nanosecond time resolution
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(
-feature = "std",
-derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
+    feature = "std",
+    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
 )]
 #[repr(transparent)]
 pub struct NanosecondResolution(pub u32);
@@ -27,8 +27,8 @@ pub struct NanosecondResolution(pub u32);
 /// Nanosecond high bits
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(
-feature = "std",
-derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
+    feature = "std",
+    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
 )]
 #[repr(transparent)]
 pub struct NanosecondsHighBits(pub [u8; 4]);
@@ -36,8 +36,8 @@ pub struct NanosecondsHighBits(pub [u8; 4]);
 /// Nanosecond low bits
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(
-feature = "std",
-derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
+    feature = "std",
+    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
 )]
 #[repr(transparent)]
 pub struct NanosecondsLowBits(pub [u8; 4]);
@@ -45,8 +45,8 @@ pub struct NanosecondsLowBits(pub [u8; 4]);
 /// Wall clock identifier, indicates the time domain
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[cfg_attr(
-feature = "std",
-derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
+    feature = "std",
+    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
 )]
 #[repr(transparent)]
 pub struct WallClockId(pub u16);
@@ -237,7 +237,6 @@ impl From<WallClockId> for u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use proptest::prelude::*;
 
     #[test]
     fn const_helpers() {
@@ -276,10 +275,16 @@ mod tests {
             Nanoseconds::from_parts_truncate(low_bits, high_bits)
         );
     }
+}
+
+#[cfg(all(test, feature = "test_support"))]
+mod advanced_tests {
+    use super::*;
+    use proptest::prelude::*;
 
     proptest! {
         #[test]
-        fn round_trip_time(raw_time_in in 0_u64..=Nanoseconds::MAX.0) {
+        fn round_trip_time(raw_time_in in 0_u64..=Nanoseconds::MAX.get()) {
             let t = Nanoseconds::new(raw_time_in).unwrap();
             prop_assert_eq!(t.get(), raw_time_in);
             let (low_bits, high_bits) = t.split();

--- a/src/time.rs
+++ b/src/time.rs
@@ -8,26 +8,46 @@
 ///
 /// This can represent approximately 73 years.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(
+feature = "std",
+derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
+)]
 #[repr(transparent)]
 pub struct Nanoseconds(u64);
 
 /// Nanosecond time resolution
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(
+feature = "std",
+derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
+)]
 #[repr(transparent)]
 pub struct NanosecondResolution(pub u32);
 
 /// Nanosecond high bits
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[cfg_attr(
+feature = "std",
+derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
+)]
 #[repr(transparent)]
 pub struct NanosecondsHighBits(pub [u8; 4]);
 
 /// Nanosecond low bits
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[cfg_attr(
+feature = "std",
+derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
+)]
 #[repr(transparent)]
 pub struct NanosecondsLowBits(pub [u8; 4]);
 
 /// Wall clock identifier, indicates the time domain
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(
+feature = "std",
+derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
+)]
 #[repr(transparent)]
 pub struct WallClockId(pub u16);
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,6 +2,7 @@
 
 use core::mem;
 use core::mem::MaybeUninit;
+use modality_probe::wire::report::SequenceNumber;
 use modality_probe::*;
 use proptest::prelude::*;
 use std::convert::{TryFrom, TryInto};
@@ -119,7 +120,7 @@ fn happy_path_backend_service() -> Result<(), ModalityProbeError> {
     let log_report = wire::WireReport::new(&backend[..bytes_written.get()])
         .expect("Could not read from bulk report format bytes");
     assert_eq!(Ok(ProbeId::try_from(123).unwrap()), log_report.probe_id());
-    assert_eq!(log_report.seq_num(), 0);
+    assert_eq!(log_report.seq_num(), SequenceNumber::from(0));
 
     assert_eq!(
         log_report.n_clocks(),
@@ -156,7 +157,7 @@ fn happy_path_backend_service() -> Result<(), ModalityProbeError> {
     let bytes_written = probe.report(&mut backend)?.unwrap();
     let log_report = wire::WireReport::new(&backend[..bytes_written.get()]).unwrap();
     assert_eq!(Ok(ProbeId::try_from(123).unwrap()), log_report.probe_id());
-    assert_eq!(log_report.seq_num(), 1);
+    assert_eq!(log_report.seq_num(), SequenceNumber::from(1));
 
     Ok(())
 }


### PR DESCRIPTION
Also split out "test_support" feature from "std" and make it so that regular `cargo test` and `cargo build` work out of the box for all combinations of features.