### PR TITLE
Fenced ring buffer more strongly associates wall clock times with buddy entries

### DIFF
--- a/fenced-ring-buffer/src/test_support.rs
+++ b/fenced-ring-buffer/src/test_support.rs
@@ -8,6 +8,10 @@ use std::sync::atomic::{fence, Ordering};
 pub(crate) struct OrderedEntry(u32);
 
 impl Entry for OrderedEntry {
+    fn is_mega_variable_prefix(&self) -> bool {
+        false
+    }
+
     fn is_prefix(&self) -> bool {
         assert!(!self.is_suffix());
         self.is_prefix_unchecked()
@@ -74,6 +78,19 @@ impl OutputOrderedEntry {
                         assert_eq!(first.to_index() as u64, current_index);
                         assert_eq!(second.to_index() as u64, current_index + 1);
                         current_index += 2;
+                    }
+                    WholeEntry::Triple(first, second, third) => {
+                        assert_eq!(first.to_index() as u64, current_index);
+                        assert_eq!(second.to_index() as u64, current_index + 1);
+                        assert_eq!(third.to_index() as u64, current_index + 2);
+                        current_index += 3;
+                    }
+                    WholeEntry::Quad(first, second, third, fourth) => {
+                        assert_eq!(first.to_index() as u64, current_index);
+                        assert_eq!(second.to_index() as u64, current_index + 1);
+                        assert_eq!(third.to_index() as u64, current_index + 2);
+                        assert_eq!(fourth.to_index() as u64, current_index + 3);
+                        current_index += 4;
                     }
                 },
             }

--- a/fuzz/fuzz_targets/fenced_ring_buffer_operations.rs
+++ b/fuzz/fuzz_targets/fenced_ring_buffer_operations.rs
@@ -33,6 +33,9 @@ enum Op {
 struct NumEntry(u32);
 
 impl Entry for NumEntry {
+    fn is_mega_variable_prefix(&self) -> bool {
+        false
+    }
     /// Return true if entry is the first in a double entry
     fn is_prefix(&self) -> bool {
         self.0 & 0b10000000_00000000_00000000_00000000 != 0

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -494,12 +494,12 @@ proptest! {
         let second_to_last_item = unsafe { log::LogEntry::new_unchecked(second_to_last_item) };
 
         // If the second-to-last item is not a two-item log entry
-        if !second_to_last_item.has_clock_bit_set()
+        if !second_to_last_item.has_logical_clock_bit_set()
             && !second_to_last_item.has_event_with_payload_bit_set()
             && !second_to_last_item.has_wall_clock_time_bits_set() {
             // Then the last item also must not be the start of a multi-item entry
             prop_assert!(
-                !last_item.has_clock_bit_set(),
+                !last_item.has_logical_clock_bit_set(),
                 "Last item has clock bit set: 0x{:X}",
                 last_item.raw()
             );
@@ -579,7 +579,7 @@ proptest! {
         ]);
         let second_to_last_item = unsafe { log::LogEntry::new_unchecked(second_to_last_item) };
 
-        if second_to_last_item.has_clock_bit_set() {
+        if second_to_last_item.has_logical_clock_bit_set() {
             // The first clock is always the self-clock, followed by an interaction clock
             prop_assert_eq!(
                 second_to_last_item.interpret_as_logical_clock_probe_id(),


### PR DESCRIPTION
More specifically, we more deeply support the tight relationship between wall clock time entry-pairs and their following content.
* Adds `Triple` and `Quad` variants of `WholeEntry`. These cover the paired WCT + something-else variations
* Now that the FRB's `WholeEntry` can more completely cover the WCT cases, reduce some of the double-WholeEntry peeking and special casing.
* The effects necessary to continue the extremely thin layer of abstraction that the low-level `Entry` trait is providing over the `LogEntry` data format is papered with tongue-in-cheek naming for the relevant concepts, e.g. `is_mega_variable_prefix` means "the kind of `Entry` that signals that it precedes both a certainly-following entry with more content but also one OR two further entries, which we won't be able to know how many of until we read more.
* Rename `has_clock_bit_set` to `has_logical_clock_bit_set` for clarity.