### PR TITLE
Split out the serde and schemars feature flags specifically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [features]
 default = []
-std = ["serde", "schemars"]
+std = []
 test_support = ["proptest"]
 debug-collector-access = ["field-offset"]
 
@@ -32,7 +32,7 @@ fixed-slice-vec = "0.8.0"
 fenced-ring-buffer = { path = "./fenced-ring-buffer" }
 
 # Used if the std feature is enabled.
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 proptest = { version = "1.0", optional = true , default-features = false}
 schemars = { version = "0.6.5", optional = true }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -12,10 +12,8 @@ use core::num::NonZeroU32;
 /// ProbeId::MAX_ID.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
-#[cfg_attr(
-    feature = "std",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ProbeId(
     /* Never make this inner field truly public */ pub(crate) NonZeroU32,
 );
@@ -174,10 +172,8 @@ fallible_sizing_try_from_impl_with_internal!(isize, EventId, InvalidEventId, Inv
 
 /// Uniquely identify an event or kind of event.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(
-    feature = "std",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct EventId(NonZeroU32);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,6 @@ use core::{
 };
 
 use fixed_slice_vec::single::{embed_uninit, EmbedValueError, SplitUninitError};
-#[cfg(feature = "std")]
-use serde::{Deserialize, Serialize};
 use static_assertions::{assert_cfg, const_assert};
 
 pub use error::*;
@@ -72,7 +70,8 @@ impl PartialOrd for CausalSnapshot {
 /// The epoch part of a probe's logical clock
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ProbeEpoch(pub u16);
 
 impl ProbeEpoch {
@@ -111,7 +110,8 @@ impl From<ProbeEpoch> for u16 {
 /// The clock part of a probe's logical clock
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ProbeTicks(pub u16);
 
 impl ProbeTicks {
@@ -156,7 +156,8 @@ pub fn unpack_clock_word(w: u32) -> (ProbeEpoch, ProbeTicks) {
 /// A single logical clock, usable as an entry in a vector clock
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[repr(C)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct LogicalClock {
     /// The probe that this clock is tracking
     /// Equivalent structurally to a u32.

--- a/src/time.rs
+++ b/src/time.rs
@@ -8,46 +8,36 @@
 ///
 /// This can represent approximately 73 years.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(
-    feature = "std",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Nanoseconds(u64);
 
 /// Nanosecond time resolution
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(
-    feature = "std",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct NanosecondResolution(pub u32);
 
 /// Nanosecond high bits
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
-#[cfg_attr(
-    feature = "std",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct NanosecondsHighBits(pub [u8; 4]);
 
 /// Nanosecond low bits
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
-#[cfg_attr(
-    feature = "std",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct NanosecondsLowBits(pub [u8; 4]);
 
 /// Wall clock identifier, indicates the time domain
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[cfg_attr(
-    feature = "std",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct WallClockId(pub u16);
 

--- a/src/wire/report.rs
+++ b/src/wire/report.rs
@@ -17,10 +17,8 @@ assert_eq_size!(LogEntry, u32);
 /// The nth report the probe has produced in its current
 /// instantiation.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-#[cfg_attr(
-    feature = "std",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct SequenceNumber(pub u64);
 

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,9 @@
 set -ex
 
 cargo build --all
-cargo test --workspace --features "std, debug-collector-access"
+cargo test --features "serde"
+cargo test --features "std schemars"
+cargo test --features "debug-collector-access"
 cargo test --workspace
 
 (


### PR DESCRIPTION
* No longer will requiring `std` also imply you want both `schemars` and `serde`
* `serde` as a feature can be used in no-std mode